### PR TITLE
Pin boost versions

### DIFF
--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -21,8 +21,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with: 
-        submodules: 'true'
+        submodules: 'false'
     
+    -name: Checkout submodule
+      working-directory: ${{github.workspace}}
+      run: |
+      git pull --recurse-submodules
+      git submodule update --recursive 
+
     - name: Compute submodule status
       working-directory: ${{github.workspace}}
       run: (git submodule status > ${{env.SUBMODS_TXT}}) && (cat ${{env.SUBMODS_TXT}})

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -24,7 +24,7 @@ jobs:
         submodules: 'false'
 
     - name: Checkout submodule
-      run: git pull --recurse-submodules && git submodule update --recursive 
+      run: git submodule update --init --recursive
 
     - name: Compute submodule status
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -22,8 +22,8 @@ jobs:
     - uses: actions/checkout@v2
       with: 
         submodules: 'false'
-    
-    -name: Checkout submodule
+
+    - name: Checkout submodule
       run: git pull --recurse-submodules && git submodule update --recursive 
 
     - name: Compute submodule status

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -24,10 +24,7 @@ jobs:
         submodules: 'false'
     
     -name: Checkout submodule
-      working-directory: ${{github.workspace}}
-      run: |
-      git pull --recurse-submodules
-      git submodule update --recursive 
+      run: git pull --recurse-submodules && git submodule update --recursive 
 
     - name: Compute submodule status
       working-directory: ${{github.workspace}}

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -42,7 +42,7 @@ jobs:
       with:
           # vcpkg cache files are stored in `~/.cache/vcpkg/archives` on Linux
           path: ~/.cache/vcpkg/archives
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('base/vcpkg.json', 'base/CMakeLists.txt') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('base/vcpkg.json', 'base/CMakeLists.txt','vcpkg/baseline.json') }}
           restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
     
     - name: Install build dependecies

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -53,33 +53,33 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=OFF -DENABLE_CUDA=OFF ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
 
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+  #   - name: Build
+  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      run: build/aprapipesut --log_format=JUNIT --log_sink=CI_test_result_ubuntu.xml
+  #   - name: Test
+  #     run: build/aprapipesut --log_format=JUNIT --log_sink=CI_test_result_ubuntu.xml
     
-    - name: Upload Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-       name: Unit Test Results
-       path: |
-         CI_test_result_ubuntu.xml
+  #   - name: Upload Test Results
+  #     if: always()
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #      name: Unit Test Results
+  #      path: |
+  #        CI_test_result_ubuntu.xml
     
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
-      with:
-        files: CI_test_result_ubuntu.xml
+  #   - name: Publish Unit Test Results
+  #     uses: EnricoMi/publish-unit-test-result-action/composite@v1
+  #     if: always()
+  #     with:
+  #       files: CI_test_result_ubuntu.xml
 
-  event_file:
-    name: "Event File"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Upload
-        uses: actions/upload-artifact@v2
-        with:
-          name: Event File
-          path: ${{ github.event_path }}
+  # event_file:
+  #   name: "Event File"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Upload
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: Event File
+  #         path: ${{ github.event_path }}
           

--- a/.github/workflows/cmake_linux_x64_no_cuda.yml
+++ b/.github/workflows/cmake_linux_x64_no_cuda.yml
@@ -53,33 +53,33 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=OFF -DENABLE_CUDA=OFF ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
 
-  #   - name: Build
-  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-  #   - name: Test
-  #     run: build/aprapipesut --log_format=JUNIT --log_sink=CI_test_result_ubuntu.xml
+    - name: Test
+      run: build/aprapipesut --log_format=JUNIT --log_sink=CI_test_result_ubuntu.xml
     
-  #   - name: Upload Test Results
-  #     if: always()
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #      name: Unit Test Results
-  #      path: |
-  #        CI_test_result_ubuntu.xml
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+       name: Unit Test Results
+       path: |
+         CI_test_result_ubuntu.xml
     
-  #   - name: Publish Unit Test Results
-  #     uses: EnricoMi/publish-unit-test-result-action/composite@v1
-  #     if: always()
-  #     with:
-  #       files: CI_test_result_ubuntu.xml
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      if: always()
+      with:
+        files: CI_test_result_ubuntu.xml
 
-  # event_file:
-  #   name: "Event File"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Upload
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: Event File
-  #         path: ${{ github.event_path }}
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
           

--- a/.github/workflows/cmake_windows_x64_no_cuda.yml
+++ b/.github/workflows/cmake_windows_x64_no_cuda.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF -G "Visual Studio 15 2017" -A x64 ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
     
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake_windows_x64_no_cuda.yml
+++ b/.github/workflows/cmake_windows_x64_no_cuda.yml
@@ -50,33 +50,33 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF -A x64 ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
     
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+  #   - name: Build
+  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-    - name: Test
-      run:  ${{github.workspace}}/build/RelWithDebInfo/aprapipesut.exe --log_format=JUNIT --log_sink=CI_test_result_windows.xml
+  #   - name: Test
+  #     run:  ${{github.workspace}}/build/RelWithDebInfo/aprapipesut.exe --log_format=JUNIT --log_sink=CI_test_result_windows.xml
     
-    - name: Upload Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-       name: Unit Test Results
-       path: |
-         CI_test_result_windows.xml
+  #   - name: Upload Test Results
+  #     if: always()
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #      name: Unit Test Results
+  #      path: |
+  #        CI_test_result_windows.xml
     
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
-      with:
-        files: CI_test_result_windows.xml
+  #   - name: Publish Unit Test Results
+  #     uses: EnricoMi/publish-unit-test-result-action/composite@v1
+  #     if: always()
+  #     with:
+  #       files: CI_test_result_windows.xml
 
-  event_file:
-    name: "Event File"
-    runs-on: windows-latest
-    steps:
-      - name: Upload
-        uses: actions/upload-artifact@v2
-        with:
-          name: Event File
-          path: ${{ github.event_path }}
+  # event_file:
+  #   name: "Event File"
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Upload
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: Event File
+  #         path: ${{ github.event_path }}
           

--- a/.github/workflows/cmake_windows_x64_no_cuda.yml
+++ b/.github/workflows/cmake_windows_x64_no_cuda.yml
@@ -50,33 +50,33 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF -A x64 ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
     
-  #   - name: Build
-  #     run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-  #   - name: Test
-  #     run:  ${{github.workspace}}/build/RelWithDebInfo/aprapipesut.exe --log_format=JUNIT --log_sink=CI_test_result_windows.xml
+    - name: Test
+      run:  ${{github.workspace}}/build/RelWithDebInfo/aprapipesut.exe --log_format=JUNIT --log_sink=CI_test_result_windows.xml
     
-  #   - name: Upload Test Results
-  #     if: always()
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #      name: Unit Test Results
-  #      path: |
-  #        CI_test_result_windows.xml
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+       name: Unit Test Results
+       path: |
+         CI_test_result_windows.xml
     
-  #   - name: Publish Unit Test Results
-  #     uses: EnricoMi/publish-unit-test-result-action/composite@v1
-  #     if: always()
-  #     with:
-  #       files: CI_test_result_windows.xml
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      if: always()
+      with:
+        files: CI_test_result_windows.xml
 
-  # event_file:
-  #   name: "Event File"
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Upload
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: Event File
-  #         path: ${{ github.event_path }}
+  event_file:
+    name: "Event File"
+    runs-on: windows-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
           

--- a/.github/workflows/cmake_windows_x64_no_cuda.yml
+++ b/.github/workflows/cmake_windows_x64_no_cuda.yml
@@ -21,8 +21,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with: 
-        submodules: 'true'
+        submodules: 'false'
     
+    - name: Checkout submodule
+      run: git submodule update --init --recursive
+          
     - name: Compute submodule status
       working-directory: ${{github.workspace}}
       run: (git submodule status > ${{env.SUBMODS_TXT}}) && (type ${{env.SUBMODS_TXT}}) && (echo $Env:LOCALAPPDATA)
@@ -39,7 +42,7 @@ jobs:
       with:
           # vcpkg cache files are stored in `~/.cache/vcpkg/archives` on Linux
           path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('base/vcpkg.json', 'base/CMakeLists.txt') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('base/vcpkg.json', 'base/CMakeLists.txt','vcpkg/baseline.json') }}
           restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
 
     - name: Configure CMake

--- a/.github/workflows/cmake_windows_x64_no_cuda.yml
+++ b/.github/workflows/cmake_windows_x64_no_cuda.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF -G "Visual Studio 15 2017" -A x64 ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DENABLE_CUDA=OFF -A x64 ${{github.workspace}}/base -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake
     
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/base/include/CommonDefs.h
+++ b/base/include/CommonDefs.h
@@ -4,6 +4,7 @@
 #include <boost/container/deque.hpp>
 
 #include <map>
+#include <string>
 
 #define boost_deque boost::container::deque
 

--- a/base/include/FilenameStrategy.h
+++ b/base/include/FilenameStrategy.h
@@ -44,10 +44,10 @@ protected:
 	bool mReadLoop;
 
 	std::string mDirName;
-	int mCurrentIndex;
+	uint64_t mCurrentIndex;
 
-	int mStartIndex;
-	int mMaxIndex;
+	uint64_t mStartIndex;
+	uint64_t mMaxIndex;
 
 private:	
 	std::string GetFileNameForCurrentIndex(bool checkForExistence) const;

--- a/base/include/FilenameStrategy.h
+++ b/base/include/FilenameStrategy.h
@@ -44,10 +44,10 @@ protected:
 	bool mReadLoop;
 
 	std::string mDirName;
-	uint64_t mCurrentIndex;
+	int mCurrentIndex;
 
-	uint64_t mStartIndex;
-	uint64_t mMaxIndex;
+	int mStartIndex;
+	int mMaxIndex;
 
 private:	
 	std::string GetFileNameForCurrentIndex(bool checkForExistence) const;

--- a/base/include/FrameContainerQueue.h
+++ b/base/include/FrameContainerQueue.h
@@ -4,8 +4,6 @@
 #include "BoundBuffer.h"
 #include "CommonDefs.h"
 
-using namespace std;
-
 class FrameContainerQueue :public bounded_buffer<frame_container> {
 public:
 	FrameContainerQueue(size_t capacity);

--- a/base/include/Logger.h
+++ b/base/include/Logger.h
@@ -1,5 +1,4 @@
 #pragma once
-#define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN7
 
 #include <string>
 #include <boost/shared_ptr.hpp>

--- a/base/include/PipeLine.h
+++ b/base/include/PipeLine.h
@@ -2,8 +2,8 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/container/deque.hpp>
 #include "enum_macros.h"
+#include <string>
 
-using namespace std;
 class Module;
 // a linear pipline
 class PipeLine {
@@ -27,14 +27,14 @@ class PipeLine {
 	typedef boost::shared_ptr<Module> item_type;
 	typedef boost::container::deque< item_type > container_type;
 	
-	string mName;
+	std::string mName;
 	container_type modules;
 	bool validate();
 	bool checkCyclicDependency();
 public:
-	PipeLine(string name) :mName(name), myStatus(PL_CREATED), mPlay(false) {}
+	PipeLine(std::string name) :mName(name), myStatus(PL_CREATED), mPlay(false) {}
 	~PipeLine();
-	string getName() { return mName; }
+	std::string getName() { return mName; }
 	bool appendModule(boost::shared_ptr<Module> pModule);
 	bool init();
 	void run_all_threaded();

--- a/base/include/QuePushStrategy.h
+++ b/base/include/QuePushStrategy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CommonDefs.h"
+#include <string>
 
 class Module;
 class FrameContainerQueue;

--- a/base/vcpkg.cuda.json
+++ b/base/vcpkg.cuda.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
-  "name": "apra-pipes-arm64",
+  "name": "apra-pipes-x64-cuda",
   "version": "0.0.1",
+  "builtin-baseline": "c0c11264c17c8323acb62e9bcc489217433a2383",
   "dependencies": [
     {
       "name": "opencv4",
@@ -19,9 +20,10 @@
     "boost-chrono",
     "boost-test",
     "boost-iostreams",
-    "zxing-cpp",
+    "nu-book-zxing-cpp",
     "liblzma",
     "bzip2",
-    "zlib"
+    "zlib",
+    "sfml"
   ]
 }

--- a/base/vcpkg.jetson.json
+++ b/base/vcpkg.jetson.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-arm64",
   "version": "0.0.1",
+  "builtin-baseline": "c0c11264c17c8323acb62e9bcc489217433a2383",
   "dependencies": [
     {
       "name": "opencv4",
@@ -19,12 +20,12 @@
     "boost-chrono",
     "boost-test",
     "boost-iostreams",
-    "zxing-cpp",
+    "nu-book-zxing-cpp",
     "liblzma",
     "bzip2",
-    "zlib"
+    "zlib",
+    "sfml"
   ],
-  "builtin-baseline": "1b664707c109f5d48b0b142e96117a53deb653be",
   "overrides": [
       {
           "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -20,7 +20,7 @@
     "boost-chrono",
     "boost-test",
     "boost-iostreams",
-    "zxing-cpp",
+    "nu-book-zxing-cpp",
     "liblzma",
     "bzip2",
     "zlib",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-arm64",
   "version": "0.0.1",
+  "builtin-baseline": "c0c11264c17c8323acb62e9bcc489217433a2383",
   "dependencies": [
     {
       "name": "opencv4",

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,12 +1,12 @@
 mkdir _build
 cd _build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_CUDA=OFF -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 ../base 
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_CUDA=OFF -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -G "Visual Studio 15 2017" -A x64 -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 ../base 
 cmake --build .
 cd ..
 pause
 
 mkdir _debugbuild
 cd _debugbuild
-cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_CUDA=OFF -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 ../base 
+cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_CUDA=OFF -DENABLE_WINDOWS=ON -DENABLE_LINUX=OFF -G "Visual Studio 15 2017" -A x64 -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -A x64 ../base 
 cmake --build .
 pause


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #65 

Description

Using a branch from the vcpkg fork . Made changes to version/baseline.json to pin boost to 1.76.0

Alternative(s) considered

Yes the other alternative is to override all boost libraries. But this will clutter the manifest.json file. Used Method 2 described here https://github.com/vicroms/vcpkg/blob/versioning/docs2/docs/examples/modify-baseline-to-pin-old-boost.md

Type Choose one: Bug fix

**Screenshots (if applicable)**

**Checklist**

- [ ] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
