### PR TITLE
Updated LINUX flag to ENABLE_LINUX in base/CMakeLists.txt

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -207,12 +207,12 @@ SET(GENERIC_FILES_H
 	include/QRReader.h
 )
 
-IF(LINUX)
+IF(ENABLE_LINUX)
 	list(APPEND CORE_FILES src/KeyboardListener.cpp)
 	list(APPEND CORE_FILES_H include/KeyboardListener.h)
 	list(APPEND GENERIC_FILES src/VirtualCameraSink.cpp)
 	list(APPEND GENERIC_FILES_H include/VirtualCameraSink.h)
-ENDIF(LINUX)
+ENDIF(ENABLE_LINUX)
 
 SET(IP_FILES
 	src/ApraLines.cpp
@@ -451,12 +451,12 @@ SET(UT_FILES
 	${CUDA_UT_FILES}
 )
 
-IF(LINUX)
+IF(ENABLE_LINUX)
 	list(APPEND UT_FILES
 	test/virtualcamerasink_tests.cpp
 	test/QRReader_tests.cpp
 	)
-ENDIF(LINUX)
+ENDIF(ENABLE_LINUX)
 
 add_executable(aprapipesut ${UT_FILES})
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

This is a trivial issue. I have fixed CMakeLists include errors for VirtualCameraSink.

**Description**

Upon running the bulid_jetson script, the nvarguscamera_tests throws error stating an undefined reference to the class of VirtualCameraSink.
The issue was with the flag used to include the VirtualCameraSink source and include files. Updating the flag from LINUX to ENABLE_LINUX fixed the issue.

**Alternative(s) considered**

--

**Type**

Bug fix

**Screenshots (if applicable)**

**Checklist**

- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
