### PR TITLE
added support for disabling sieve

### DIFF
--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -149,8 +149,7 @@ public:
 	vector<string> getAllOutputPinsByType(int type);
 	void addOutputPin(framemetadata_sp& metadata, string& pinId);
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
-	bool setNext(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
-	bool setNext(boost::shared_ptr<Module> next, bool open, bool sieve);
+	bool setNext(boost::shared_ptr<Module> next, bool open = true, bool sieve = true); // take all the output pins			
 	bool addFeedback(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
 	bool addFeedback(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
 	boost_deque<boost::shared_ptr<Module>> getConnectedModules();

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -150,6 +150,7 @@ public:
 	void addOutputPin(framemetadata_sp& metadata, string& pinId);
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
 	bool setNext(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
+	bool setNext(boost::shared_ptr<Module> next, bool open, bool sieve);
 	bool addFeedback(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
 	bool addFeedback(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
 	boost_deque<boost::shared_ptr<Module>> getConnectedModules();
@@ -285,8 +286,8 @@ protected:
 	string getInputPinIdByType(int type);
 	string getOutputPinIdByType(int type);		
 	
-	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback); // take all the output pins			
-	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open, bool isFeedback); 
+	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback, bool sieve); // take all the output pins			
+	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open, bool isFeedback, bool sieve); 
 	void addInputPin(framemetadata_sp& metadata, string& pinId, bool isFeedback); 
 	virtual void addInputPin(framemetadata_sp& metadata, string& pinId); // throws exception if validation fails	
 	boost::shared_ptr<FrameContainerQueue> getQue() { return mQue; }
@@ -347,6 +348,7 @@ private:
 	bool mRunning;
 	uint32_t mStopCount;
 	uint32_t mForwardPins;
+	bool mIsSieveEnabled = true;
 	boost::shared_ptr<FrameFactory> mpFrameFactory;
 	boost::shared_ptr<FrameFactory> mpCommandFactory;
 	boost::shared_ptr<PaceMaker> pacer;

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -304,6 +304,7 @@ protected:
 	bool handlePausePlay(bool play);
 	virtual void notifyPlay(bool play) {}
 private:	
+	void setSieveDisabledFlag(bool sieve);
 	frame_sp makeFrame(size_t size, framefactory_sp& framefactory);
 	bool push(frame_container frameContainer); //exchanges the buffer 
 	bool try_push(frame_container frameContainer); //tries to exchange the buffer
@@ -347,7 +348,7 @@ private:
 	bool mRunning;
 	uint32_t mStopCount;
 	uint32_t mForwardPins;
-	bool mIsSieveEnabled = true;
+	bool mIsSieveDisabledForAny = false;
 	boost::shared_ptr<FrameFactory> mpFrameFactory;
 	boost::shared_ptr<FrameFactory> mpCommandFactory;
 	boost::shared_ptr<PaceMaker> pacer;

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -346,11 +346,6 @@ bool Module::setNext(boost::shared_ptr<Module> next, vector<string> &pinIdArr, b
 }
 
 // default - open, sieve is enabled - feedback false
-bool Module::setNext(boost::shared_ptr<Module> next, bool open) 
-{
-	return setNext(next, open, true);
-}
-
 bool Module::setNext(boost::shared_ptr<Module> next, bool open, bool sieve)
 {
 	return setNext(next, open, false, sieve);


### PR DESCRIPTION
Fixes #117 

**Description**
- Added support for disabling sieving of input pins.
- Added a flag called `sieve` in `setNext` methods to allow passing through of input pins of the module as output pins as well. 
- Updated core `setNext` logic.
- If a module has at least one connection with sieve disabled, the number of `EOP` frames sent downstream are equal to sum of number of input and output pins of the module.
 
**Alternative(s) considered**
- None

**Type** 
- Feature

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
