### PR TITLE
Sieve compliance

### DIFF
--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -146,7 +146,7 @@ public:
 	uint64_t getTickCounter();
 		
 	string addOutputPin(framemetadata_sp& metadata); // throw exception
-	vector<string> getAllOutputPinsByType(int type);
+	vector<string> getAllOutputPinsByType(int type, bool implicit = false);
 	void addOutputPin(framemetadata_sp& metadata, string& pinId);
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
 	bool setNext(boost::shared_ptr<Module> next, bool open = true, bool sieve = true); // take all the output pins			
@@ -270,7 +270,15 @@ protected:
 	virtual bool validateOutputPins(); // invoked with addOutputPin
 	virtual bool validateInputOutputPins() { return validateInputPins() && validateOutputPins(); } // invoked during Module::init before anything else
 				
-	size_t getNumberOfOutputPins() { return mOutputPinIdFrameFactoryMap.size(); }
+	size_t getNumberOfOutputPins(bool implicit = false) 
+	{ 
+		auto pinCount = mOutputPinIdFrameFactoryMap.size(); 
+		if (implicit) 
+		{ 
+			pinCount += mInputPinIdMetadataMap.size(); 
+		} 
+		return pinCount;
+	}
 	size_t getNumberOfInputPins() { return mInputPinIdMetadataMap.size(); }
 	framemetadata_sp getFirstInputMetadata();
 	framemetadata_sp getFirstOutputMetadata();
@@ -278,12 +286,12 @@ protected:
 	framefactory_by_pin& getOutputFrameFactory() { return mOutputPinIdFrameFactoryMap; }
 	framemetadata_sp getInputMetadataByType(int type);
 	int getNumberOfInputsByType(int type);
-	int getNumberOfOutputsByType(int type);
+	int getNumberOfOutputsByType(int type, bool implicit = false);
 	framemetadata_sp getOutputMetadataByType(int type);
 	bool isMetadataEmpty(framemetadata_sp& metadata);
 	bool isFrameEmpty(frame_sp& frame);
 	string getInputPinIdByType(int type);
-	string getOutputPinIdByType(int type);		
+	string getOutputPinIdByType(int type, bool implicit = false);		
 	
 	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback, bool sieve); // take all the output pins			
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open, bool isFeedback, bool sieve); 

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -146,7 +146,7 @@ public:
 	uint64_t getTickCounter();
 		
 	string addOutputPin(framemetadata_sp& metadata); // throw exception
-	vector<string> getAllOutputPinsByType(int type, bool implicit = false);
+	vector<string> getAllOutputPinsByType(int type);
 	void addOutputPin(framemetadata_sp& metadata, string& pinId);
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
 	bool setNext(boost::shared_ptr<Module> next, bool open = true, bool sieve = true); // take all the output pins			
@@ -270,10 +270,11 @@ protected:
 	virtual bool validateOutputPins(); // invoked with addOutputPin
 	virtual bool validateInputOutputPins() { return validateInputPins() && validateOutputPins(); } // invoked during Module::init before anything else
 				
-	size_t getNumberOfOutputPins(bool implicit = false) 
+	size_t getNumberOfOutputPins(bool implicit = true) 
 	{ 
 		auto pinCount = mOutputPinIdFrameFactoryMap.size(); 
-		if (implicit) 
+		// override the implicit behaviour 
+		if (!implicit) 
 		{ 
 			pinCount += mInputPinIdMetadataMap.size(); 
 		} 
@@ -286,12 +287,12 @@ protected:
 	framefactory_by_pin& getOutputFrameFactory() { return mOutputPinIdFrameFactoryMap; }
 	framemetadata_sp getInputMetadataByType(int type);
 	int getNumberOfInputsByType(int type);
-	int getNumberOfOutputsByType(int type, bool implicit = false);
+	int getNumberOfOutputsByType(int type);
 	framemetadata_sp getOutputMetadataByType(int type);
 	bool isMetadataEmpty(framemetadata_sp& metadata);
 	bool isFrameEmpty(frame_sp& frame);
 	string getInputPinIdByType(int type);
-	string getOutputPinIdByType(int type, bool implicit = false);		
+	string getOutputPinIdByType(int type);		
 	
 	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback, bool sieve); // take all the output pins			
 	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open, bool isFeedback, bool sieve); 

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -741,7 +741,7 @@ string getPinIdByType(int type, framefactory_by_pin &metadataMap)
 	return "";
 }
 
-vector<string> Module::getAllOutputPinsByType(int type, bool implicit)
+vector<string> Module::getAllOutputPinsByType(int type)
 {
 	vector<string> pins;
 
@@ -754,18 +754,6 @@ vector<string> Module::getAllOutputPinsByType(int type, bool implicit)
 		}
 	}
 
-	if (implicit) // also send the input pins
-	{
-		pair<string, framemetadata_sp> me; // map element
-		BOOST_FOREACH(me, mInputPinIdMetadataMap)
-		{
-			if (me.second->getFrameType() == type)
-			{
-				pins.push_back(me.first);
-			}
-		}
-	}
-
 	return pins;
 }
 
@@ -774,14 +762,9 @@ string Module::getInputPinIdByType(int type)
 	return getPinIdByType(type, mInputPinIdMetadataMap);
 }
 
-string Module::getOutputPinIdByType(int type, bool implicit)
+string Module::getOutputPinIdByType(int type)
 {
-	auto pinId = getPinIdByType(type, mOutputPinIdFrameFactoryMap);
-	if (pinId.empty() && implicit)
-	{
-		pinId = getPinIdByType(type, mInputPinIdMetadataMap);
-	}
-	return pinId;
+	return getPinIdByType(type, mOutputPinIdFrameFactoryMap);
 }
 
 framemetadata_sp getMetadataByType(int type, metadata_by_pin &metadataMap)
@@ -858,14 +841,9 @@ int Module::getNumberOfInputsByType(int type)
 	return getNumberOfPinsByType(type, mInputPinIdMetadataMap);
 }
 
-int Module::getNumberOfOutputsByType(int type, bool implicit)
+int Module::getNumberOfOutputsByType(int type)
 {
-	auto pins = getNumberOfPinsByType(type, mOutputPinIdFrameFactoryMap);
-	if (implicit)
-	{
-		pins += getNumberOfInputsByType(type);
-	}
-	return pins;
+	return getNumberOfPinsByType(type, mOutputPinIdFrameFactoryMap);
 }
 
 bool Module::isMetadataEmpty(framemetadata_sp &metatata)

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -741,7 +741,7 @@ string getPinIdByType(int type, framefactory_by_pin &metadataMap)
 	return "";
 }
 
-vector<string> Module::getAllOutputPinsByType(int type)
+vector<string> Module::getAllOutputPinsByType(int type, bool implicit)
 {
 	vector<string> pins;
 
@@ -754,6 +754,18 @@ vector<string> Module::getAllOutputPinsByType(int type)
 		}
 	}
 
+	if (implicit) // also send the input pins
+	{
+		pair<string, framemetadata_sp> me; // map element
+		BOOST_FOREACH(me, mInputPinIdMetadataMap)
+		{
+			if (me.second->getFrameType() == type)
+			{
+				pins.push_back(me.first);
+			}
+		}
+	}
+
 	return pins;
 }
 
@@ -762,9 +774,14 @@ string Module::getInputPinIdByType(int type)
 	return getPinIdByType(type, mInputPinIdMetadataMap);
 }
 
-string Module::getOutputPinIdByType(int type)
+string Module::getOutputPinIdByType(int type, bool implicit)
 {
-	return getPinIdByType(type, mOutputPinIdFrameFactoryMap);
+	auto pinId = getPinIdByType(type, mOutputPinIdFrameFactoryMap);
+	if (pinId.empty() && implicit)
+	{
+		pinId = getPinIdByType(type, mInputPinIdMetadataMap);
+	}
+	return pinId;
 }
 
 framemetadata_sp getMetadataByType(int type, metadata_by_pin &metadataMap)
@@ -841,9 +858,14 @@ int Module::getNumberOfInputsByType(int type)
 	return getNumberOfPinsByType(type, mInputPinIdMetadataMap);
 }
 
-int Module::getNumberOfOutputsByType(int type)
+int Module::getNumberOfOutputsByType(int type, bool implicit)
 {
-	return getNumberOfPinsByType(type, mOutputPinIdFrameFactoryMap);
+	auto pins = getNumberOfPinsByType(type, mOutputPinIdFrameFactoryMap);
+	if (implicit)
+	{
+		pins += getNumberOfInputsByType(type);
+	}
+	return pins;
 }
 
 bool Module::isMetadataEmpty(framemetadata_sp &metatata)


### PR DESCRIPTION
Fixes #119 

**Description**

Updated the `getNumberOfOutputPins` to take implicit argument. Considers input pins too if implicit is false.

**Alternative(s) considered**
None

**Type**
- Feature 

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
