### PR TITLE
Implemented Flush Queue functionality for modules

### DIFF
--- a/base/include/BoundBuffer.h
+++ b/base/include/BoundBuffer.h
@@ -119,6 +119,15 @@ public:
 		lock.unlock();
 	}
 
+	void flush() {
+		boost::mutex::scoped_lock lock(m_mutex);
+		m_container.clear();
+		m_unread = 0;
+		m_not_full.notify_one();
+
+		lock.unlock();
+	}
+
 	void accept() {
 		boost::mutex::scoped_lock lock(m_mutex);
 		m_accept = true;

--- a/base/include/BoundBuffer.h
+++ b/base/include/BoundBuffer.h
@@ -124,8 +124,6 @@ public:
 		m_container.clear();
 		m_unread = 0;
 		m_not_full.notify_one();
-
-		lock.unlock();
 	}
 
 	void accept() {

--- a/base/include/FrameContainerQueue.h
+++ b/base/include/FrameContainerQueue.h
@@ -16,6 +16,7 @@ public:
 
 	virtual bool isFull();
 	virtual void clear();
+	virtual void flush();
 	virtual void accept();
 	virtual size_t size();
 

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -171,6 +171,7 @@ public:
 	void register_consumer(boost::function<void(Module*, unsigned short)>, bool bFatal=false);
 	boost::shared_ptr<PaceMaker> getPacer() { return pacer; }	
 	static frame_sp getFrameByType(frame_container& frames, int frameType);	
+	virtual void flushQue();
 protected:
 	virtual boost_deque<frame_sp> getFrames(frame_container& frames);	
 	virtual bool process(frame_container& frames) { return false; }

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -170,8 +170,9 @@ public:
 	
 	void register_consumer(boost::function<void(Module*, unsigned short)>, bool bFatal=false);
 	boost::shared_ptr<PaceMaker> getPacer() { return pacer; }	
-	static frame_sp getFrameByType(frame_container& frames, int frameType);	
+	static frame_sp getFrameByType(frame_container& frames, int frameType); 
 	virtual void flushQue();
+	virtual void flushQueRecursive();
 protected:
 	virtual boost_deque<frame_sp> getFrames(frame_container& frames);	
 	virtual bool process(frame_container& frames) { return false; }

--- a/base/src/FrameContainerQueue.cpp
+++ b/base/src/FrameContainerQueue.cpp
@@ -39,6 +39,11 @@ void FrameContainerQueue::clear()
 	return bounded_buffer<frame_container>::clear();
 }
 
+void FrameContainerQueue::flush()
+{
+	return bounded_buffer<frame_container>::flush();
+}
+
 void FrameContainerQueue::accept()
 {
 	return bounded_buffer<frame_container>::accept();

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -1034,6 +1034,17 @@ bool Module::relay(boost::shared_ptr<Module> next, bool open)
 	return queueCommand(cmd);
 }
 
+void Module::flushQue()
+{
+	// recursively call the flushQue of children module
+	for (auto it = mModules.begin(); it != mModules.end(); ++it)
+	{
+		it->second->flushQue();
+	}
+	LOG_INFO << "flushQue for <" << myId << ">";
+	mQue->flush();
+}
+
 bool Module::processSourceQue()
 {
 	frame_container frames;

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -1034,14 +1034,20 @@ bool Module::relay(boost::shared_ptr<Module> next, bool open)
 	return queueCommand(cmd);
 }
 
-void Module::flushQue()
+void Module::flushQueRecursive()
 {
-	// recursively call the flushQue of children module
+	flushQue();
+
+	// recursively call the flushQue for children modules
 	for (auto it = mModules.begin(); it != mModules.end(); ++it)
 	{
-		it->second->flushQue();
+		it->second->flushQueRecursive();
 	}
-	LOG_INFO << "flushQue for <" << myId << ">";
+}
+
+void Module::flushQue()
+{
+	LOG_INFO << "mQue flushed for <" << myId << ">";
 	mQue->flush();
 }
 


### PR DESCRIPTION
Fixes #125

**Description**

- Implemented flushQue feature. 
-  On calling flushQue for a module, all the frames in the queues of downstream modules in the pipeline subtree are flushed.

**Alternative(s) considered**

None

**Type**

Type Choose one: Feature

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
