### PR TITLE
parseNalu function and mp4Writer filePathName fix.

### DIFF
--- a/base/include/H264Utils.h
+++ b/base/include/H264Utils.h
@@ -29,5 +29,5 @@ public:
 		static H264_NAL_TYPE getNALUType(const char *buffer);
 		static H264_NAL_TYPE getNALUType(Frame *frm);
 		static bool getNALUnit(const char *buffer, size_t length, size_t &offset);
-		static std::tuple<short, const_buffer, const_buffer, const_buffer> parseNalu(mutable_buffer& input);
+		static std::tuple<short, const_buffer, const_buffer> parseNalu(const const_buffer input);
 };

--- a/base/include/Mp4WriterSinkUtils.h
+++ b/base/include/Mp4WriterSinkUtils.h
@@ -4,14 +4,15 @@ class Mp4WriterSinkUtils
 {
 public:
 	Mp4WriterSinkUtils();
-	std::string getFilenameForNextFrame(uint64_t &timestamp, std::string &basefolder,
+	void getFilenameForNextFrame(std::string& nextFrameFileName ,uint64_t &timestamp, std::string &basefolder,
 		uint32_t chunkTimeInMinutes, uint32_t syncTimeInMinutes, bool &syncFlag,short& frameType, short naluType);
 	void parseTSJpeg(uint64_t &tm, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInMinutes,
-		boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder);
-	void parseTSH264(uint64_t& tm, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,
-		boost::filesystem::path& relPath, std::string& mp4FileName, bool& syncFlag,short frameType, short naluType, std::string baseFolder);
+		boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder, std::string& nextFrameFileName);
+	void parseTSH264(uint64_t& tm, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,boost::filesystem::path& relPath, 
+		std::string& mp4FileName, bool& syncFlag,short frameType, short naluType, std::string baseFolder, std::string& nextFrameFileName);
 	std::string format_hrs(int &hr);
 	std::string format_2(int &min);
+	std::string filePath(boost::filesystem::path relPath, std::string mp4FileName, std::string baseFolder);
 	~Mp4WriterSinkUtils();
 private:
 	int lastVideoMinute=0;
@@ -20,4 +21,5 @@ private:
 	std::time_t lastSyncTS;
 	std::string currentFolder;
 	boost::filesystem::path lastVideoFolderPath;
+	std::string tempNextFrameFileName;
 };

--- a/base/include/Mp4WriterSinkUtils.h
+++ b/base/include/Mp4WriterSinkUtils.h
@@ -5,10 +5,10 @@ class Mp4WriterSinkUtils
 public:
 	Mp4WriterSinkUtils();
 	void getFilenameForNextFrame(std::string& nextFrameFileName ,uint64_t &timestamp, std::string &basefolder,
-		uint32_t chunkTimeInMinutes, uint32_t syncTimeInMinutes, bool &syncFlag,short& frameType, short naluType);
-	void parseTSJpeg(uint64_t &tm, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInMinutes,
+		uint32_t chunkTimeInMinutes, uint32_t syncTimeInSeconds, bool &syncFlag,short& frameType, short naluType);
+	void parseTSJpeg(uint64_t &tm, uint32_t &chunkTimeInMinutes, uint32_t & syncTimeInSeconds,
 		boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder, std::string& nextFrameFileName);
-	void parseTSH264(uint64_t& tm, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,boost::filesystem::path& relPath, 
+	void parseTSH264(uint64_t& tm, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInSeconds,boost::filesystem::path& relPath,
 		std::string& mp4FileName, bool& syncFlag,short frameType, short naluType, std::string baseFolder, std::string& nextFrameFileName);
 	std::string format_hrs(int &hr);
 	std::string format_2(int &min);

--- a/base/src/Mp4WriterSink.cpp
+++ b/base/src/Mp4WriterSink.cpp
@@ -197,7 +197,6 @@ public:
 	const_buffer ppsBuffer;
 	const_buffer spsBuff;
 	const_buffer ppsBuff;
-	const_buffer inFrame;
 	short typeFound;
 
 	DetailH264(Mp4WriterSinkProps& _props) : DetailAbs(_props)
@@ -229,7 +228,8 @@ bool DetailJpeg::write(frame_container& frames)
 		return true;
 	}
 	short naluType = 0;
-	std::string _nextFrameFileName = mWriterSinkUtils.getFilenameForNextFrame(inJpegImageFrame->timestamp, mProps->baseFolder,
+	std::string _nextFrameFileName;
+	mWriterSinkUtils.getFilenameForNextFrame(_nextFrameFileName, inJpegImageFrame->timestamp, mProps->baseFolder,
 		mProps->chunkTime, mProps->syncTime, syncFlag ,mFrameType, naluType);
 
 	if (_nextFrameFileName == "")
@@ -297,9 +297,9 @@ bool DetailH264::write(frame_container& frames)
 		return true;
 	}
 
-	mutable_buffer& frame = *(inH264ImageFrame.get());
-	auto ret = H264Utils::parseNalu(frame);
-	tie(typeFound, inFrame, spsBuff, ppsBuff) = ret;
+	auto mFrameBuffer = const_buffer(inH264ImageFrame->data(), inH264ImageFrame->size());
+	auto ret = H264Utils::parseNalu(mFrameBuffer);
+	tie(typeFound, spsBuff, ppsBuff) = ret;
 
 	if ((spsBuff.size() !=0 ) || (ppsBuff.size() != 0))
 	{
@@ -308,7 +308,8 @@ bool DetailH264::write(frame_container& frames)
 		ppsBuffer = ppsBuff;
 	}
 
-	std::string _nextFrameFileName = mWriterSinkUtils.getFilenameForNextFrame(inH264ImageFrame->timestamp, mProps->baseFolder,
+	std::string _nextFrameFileName;
+	mWriterSinkUtils.getFilenameForNextFrame(_nextFrameFileName,inH264ImageFrame->timestamp, mProps->baseFolder,
 		mProps->chunkTime, mProps->syncTime, syncFlag,mFrameType, typeFound);
 
 	if (_nextFrameFileName == "")

--- a/base/src/Mp4WriterSinkUtils.cpp
+++ b/base/src/Mp4WriterSinkUtils.cpp
@@ -36,119 +36,10 @@ std::string Mp4WriterSinkUtils::format_2(int &num)
 	}
 }
 
-void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInMinutes,
-	boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder)
-{
-	std::chrono::milliseconds duration(ts);
-	std::chrono::seconds secondsInDuration = std::chrono::duration_cast<std::chrono::seconds>(duration);
-	std::chrono::milliseconds msecsInDuration = std::chrono::duration_cast<std::chrono::milliseconds>(duration - secondsInDuration);
-
-	std::chrono::time_point<std::chrono::system_clock> timePointInSeconds(secondsInDuration);
-	std::time_t t = std::chrono::system_clock::to_time_t(timePointInSeconds);
-	std::tm tm = *std::localtime(&t);
-	uint16_t msecs = msecsInDuration.count();
-
-	auto syncTimeInSecs = 60 * syncTimeInMinutes;
-	if ((t - lastSyncTS) >= syncTimeInSecs)
-	{
-		syncFlag = true;
-		lastSyncTS = t;
-	}
-	else
-	{
-		syncFlag = false;
-	}
-
-	// used cached values if the difference in ts is less than chunkTime
-	uint32_t chunkTimeInSecs = 60 * chunkTimeInMinutes;
-	if ((t - lastVideoTS) < chunkTimeInSecs && currentFolder == baseFolder)
-	{
-		relPath = lastVideoFolderPath;
-		mp4FileName = lastVideoName;
-		return;
-	}
-
-	// get new video path
-	std::string yyyymmdd = std::to_string(1900 + tm.tm_year) + format_2(tm.tm_mon) + format_2(tm.tm_mday);
-	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
-	mp4FileName = std::to_string(ts) + ".mp4";
-
-	// cache new values
-	currentFolder = baseFolder;
-	lastVideoTS = t;
-	lastVideoFolderPath = relPath;
-	lastVideoMinute = tm.tm_min;
-	lastVideoName = mp4FileName;
-}
-
-void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,
-	boost::filesystem::path& relPath, std::string& mp4FileName, bool& syncFlag, short frameType, short naluType, std::string baseFolder)
-{
-	std::chrono::milliseconds duration(ts);
-	std::chrono::seconds secondsInDuration = std::chrono::duration_cast<std::chrono::seconds>(duration);
-	std::chrono::milliseconds msecsInDuration = std::chrono::duration_cast<std::chrono::milliseconds>(duration - secondsInDuration);
-
-	std::chrono::time_point<std::chrono::system_clock> timePointInSeconds(secondsInDuration);
-	std::time_t t = std::chrono::system_clock::to_time_t(timePointInSeconds);
-	std::tm tm = *std::localtime(&t);
-	uint16_t msecs = msecsInDuration.count();
-
-	auto syncTimeInSecs = 60 * syncTimeInMinutes;
-	if ((t - lastSyncTS) >= syncTimeInSecs)
-	{
-		syncFlag = true;
-		lastSyncTS = t;
-	}
-	else
-	{
-		syncFlag = false;
-	}
-	// used cached values if the difference in ts is less than chunkTime
-	uint32_t chunkTimeInSecs = 60 * chunkTimeInMinutes;
-	if ((t - lastVideoTS) < chunkTimeInSecs && currentFolder == baseFolder)
-	{
-		relPath = lastVideoFolderPath;
-		mp4FileName = lastVideoName;
-		return;
-	}
-	// cannot be merged with if condition above.
-	if (naluType != H264Utils::H264_NAL_TYPE::H264_NAL_TYPE_IDR_SLICE)
-	{
-		relPath = lastVideoFolderPath;
-		mp4FileName = lastVideoName;
-		return;
-	}
-	// get new video path
-	std::string yyyymmdd = std::to_string(1900 + tm.tm_year) + format_2(tm.tm_mon) + format_2(tm.tm_mday);
-	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
-	mp4FileName = std::to_string(ts) + ".mp4";
-
-	// cache new values
-	currentFolder = baseFolder;
-	lastVideoTS = t;
-	lastVideoFolderPath = relPath;
-	lastVideoMinute = tm.tm_min;
-	lastVideoName = mp4FileName;
-}
-
-std::string Mp4WriterSinkUtils::getFilenameForNextFrame(uint64_t& timestamp, std::string& basefolder,
-	uint32_t chunkTimeInMinutes, uint32_t syncTimeInMinutes, bool& syncFlag, short& frameType , short naluType)
+std::string Mp4WriterSinkUtils::filePath(boost::filesystem::path relPath, std::string mp4FileName, std::string baseFolder)
 {
 	boost::filesystem::path finalPath;
-	std::string mp4FileName;
-	boost::filesystem::path relPath;
-
-	if (frameType == FrameMetadata::FrameType::H264_DATA)
-	{
-		parseTSH264(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, frameType, naluType, basefolder);
-	}
-	else if (frameType == FrameMetadata::FrameType::ENCODED_IMAGE)
-	{
-		parseTSJpeg(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, basefolder);
-	}
-
-	// create the folder if it does not exist
-	auto folderPath = boost::filesystem::path(basefolder) / relPath;
+	auto folderPath = boost::filesystem::path(baseFolder) / relPath;
 	if (boost::filesystem::is_directory(folderPath))
 	{
 		finalPath = folderPath / mp4FileName;
@@ -166,6 +57,126 @@ std::string Mp4WriterSinkUtils::getFilenameForNextFrame(uint64_t& timestamp, std
 		LOG_ERROR << "Check the dir permissions.";
 		return "";
 	}
+}
+
+void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInMinutes,
+	boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder, std::string& nextFrameFileName)
+{
+	std::chrono::milliseconds duration(ts);
+	std::chrono::seconds secondsInDuration = std::chrono::duration_cast<std::chrono::seconds>(duration);
+	std::chrono::milliseconds msecsInDuration = std::chrono::duration_cast<std::chrono::milliseconds>(duration - secondsInDuration);
+
+	std::chrono::time_point<std::chrono::system_clock> timePointInSeconds(secondsInDuration);
+	std::time_t t = std::chrono::system_clock::to_time_t(timePointInSeconds);
+	std::tm tm = *std::localtime(&t);
+	uint16_t msecs = msecsInDuration.count();
+
+	auto syncTimeInSecs = 60 * syncTimeInMinutes;
+	if ((t - lastSyncTS) >= syncTimeInSecs)
+	{
+		syncFlag = true;
+		lastSyncTS = t;
+	}
+	else
+	{
+		syncFlag = false;
+	}
+
+	// used cached values if the difference in ts is less than chunkTime
+	uint32_t chunkTimeInSecs = 60 * chunkTimeInMinutes;
+	if ((t - lastVideoTS) < chunkTimeInSecs && currentFolder == baseFolder)
+	{
+		relPath = lastVideoFolderPath;
+		mp4FileName = lastVideoName;
+		nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
+		return;
+	}
+
+	// get new video path
+	std::string yyyymmdd = std::to_string(1900 + tm.tm_year) + format_2(tm.tm_mon) + format_2(tm.tm_mday);
+	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
+	mp4FileName = std::to_string(ts) + ".mp4";
+
+	// cache new values
+	currentFolder = baseFolder;
+	lastVideoTS = t;
+	lastVideoFolderPath = relPath;
+	lastVideoMinute = tm.tm_min;
+	lastVideoName = mp4FileName;
+	
+	nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
+}
+void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,boost::filesystem::path& relPath, 
+	std::string& mp4FileName, bool& syncFlag, short frameType, short naluType, std::string baseFolder, std::string& nextFrameFileName)
+{
+	std::chrono::milliseconds duration(ts);
+	std::chrono::seconds secondsInDuration = std::chrono::duration_cast<std::chrono::seconds>(duration);
+	std::chrono::milliseconds msecsInDuration = std::chrono::duration_cast<std::chrono::milliseconds>(duration - secondsInDuration);
+
+	std::chrono::time_point<std::chrono::system_clock> timePointInSeconds(secondsInDuration);
+	std::time_t t = std::chrono::system_clock::to_time_t(timePointInSeconds);
+	std::tm tm = *std::localtime(&t);
+	uint16_t msecs = msecsInDuration.count();
+
+	auto syncTimeInSecs = 60 * syncTimeInMinutes;
+	if ((t - lastSyncTS) >= syncTimeInSecs)
+	{
+		syncFlag = true;
+		lastSyncTS = t;
+	}
+	else
+	{
+		syncFlag = false;
+	}
+	// used cached values if the difference in ts is less than chunkTime
+	uint32_t chunkTimeInSecs = 60 * chunkTimeInMinutes;
+	if ((t - lastVideoTS) < chunkTimeInSecs && currentFolder == baseFolder)
+	{
+		relPath = lastVideoFolderPath;
+		mp4FileName = lastVideoName;
+		nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
+		return;
+	}
+	// cannot be merged with if condition above.
+	if (naluType != H264Utils::H264_NAL_TYPE::H264_NAL_TYPE_IDR_SLICE)
+	{
+		relPath = lastVideoFolderPath;
+		mp4FileName = lastVideoName;
+		nextFrameFileName = tempNextFrameFileName;
+		return;
+	}
+	// get new video path
+	std::string yyyymmdd = std::to_string(1900 + tm.tm_year) + format_2(tm.tm_mon) + format_2(tm.tm_mday);
+	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
+	mp4FileName = std::to_string(ts) + ".mp4";
+
+	// cache new values
+	currentFolder = baseFolder;
+	lastVideoTS = t;
+	lastVideoFolderPath = relPath;
+	lastVideoMinute = tm.tm_min;
+	lastVideoName = mp4FileName;
+
+	nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
+	tempNextFrameFileName = nextFrameFileName;
+}
+
+void Mp4WriterSinkUtils::getFilenameForNextFrame(std::string& nextFrameFileName ,uint64_t& timestamp, std::string& basefolder,
+	uint32_t chunkTimeInMinutes, uint32_t syncTimeInMinutes, bool& syncFlag, short& frameType , short naluType)
+{
+	boost::filesystem::path finalPath;
+	std::string mp4FileName;
+	boost::filesystem::path relPath;
+
+	if (frameType == FrameMetadata::FrameType::H264_DATA)
+	{
+		parseTSH264(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, frameType, naluType, basefolder, nextFrameFileName);
+	}
+	else if (frameType == FrameMetadata::FrameType::ENCODED_IMAGE)
+	{
+		parseTSJpeg(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, basefolder, nextFrameFileName);
+	}
+	
 }
 
 Mp4WriterSinkUtils::~Mp4WriterSinkUtils()

--- a/base/src/Mp4WriterSinkUtils.cpp
+++ b/base/src/Mp4WriterSinkUtils.cpp
@@ -59,7 +59,7 @@ std::string Mp4WriterSinkUtils::filePath(boost::filesystem::path relPath, std::s
 	}
 }
 
-void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInMinutes,
+void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes, uint32_t &syncTimeInSeconds,
 	boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder, std::string& nextFrameFileName)
 {
 	std::chrono::milliseconds duration(ts);
@@ -71,8 +71,7 @@ void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes,
 	std::tm tm = *std::localtime(&t);
 	uint16_t msecs = msecsInDuration.count();
 
-	auto syncTimeInSecs = 60 * syncTimeInMinutes;
-	if ((t - lastSyncTS) >= syncTimeInSecs)
+	if ((t - lastSyncTS) >= syncTimeInSeconds)
 	{
 		syncFlag = true;
 		lastSyncTS = t;
@@ -106,7 +105,7 @@ void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes,
 	
 	nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
 }
-void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInMinutes,boost::filesystem::path& relPath, 
+void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInSeconds,boost::filesystem::path& relPath, 
 	std::string& mp4FileName, bool& syncFlag, short frameType, short naluType, std::string baseFolder, std::string& nextFrameFileName)
 {
 	std::chrono::milliseconds duration(ts);
@@ -118,8 +117,7 @@ void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes,
 	std::tm tm = *std::localtime(&t);
 	uint16_t msecs = msecsInDuration.count();
 
-	auto syncTimeInSecs = 60 * syncTimeInMinutes;
-	if ((t - lastSyncTS) >= syncTimeInSecs)
+	if ((t - lastSyncTS) >= syncTimeInSeconds)
 	{
 		syncFlag = true;
 		lastSyncTS = t;
@@ -162,7 +160,7 @@ void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes,
 }
 
 void Mp4WriterSinkUtils::getFilenameForNextFrame(std::string& nextFrameFileName ,uint64_t& timestamp, std::string& basefolder,
-	uint32_t chunkTimeInMinutes, uint32_t syncTimeInMinutes, bool& syncFlag, short& frameType , short naluType)
+	uint32_t chunkTimeInMinutes, uint32_t syncTimeInSeconds, bool& syncFlag, short& frameType , short naluType)
 {
 	boost::filesystem::path finalPath;
 	std::string mp4FileName;
@@ -170,11 +168,11 @@ void Mp4WriterSinkUtils::getFilenameForNextFrame(std::string& nextFrameFileName 
 
 	if (frameType == FrameMetadata::FrameType::H264_DATA)
 	{
-		parseTSH264(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, frameType, naluType, basefolder, nextFrameFileName);
+		parseTSH264(timestamp, chunkTimeInMinutes, syncTimeInSeconds, relPath, mp4FileName, syncFlag, frameType, naluType, basefolder, nextFrameFileName);
 	}
 	else if (frameType == FrameMetadata::FrameType::ENCODED_IMAGE)
 	{
-		parseTSJpeg(timestamp, chunkTimeInMinutes, syncTimeInMinutes, relPath, mp4FileName, syncFlag, basefolder, nextFrameFileName);
+		parseTSJpeg(timestamp, chunkTimeInMinutes, syncTimeInSeconds, relPath, mp4FileName, syncFlag, basefolder, nextFrameFileName);
 	}
 	
 }

--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -30,7 +30,7 @@ void write(std::string inFolderPath, std::string outFolderPath, int width, int h
 	auto encodedImageMetadata = framemetadata_sp(new EncodedImageMetadata(width, height));
 	fileReader->addOutputPin(encodedImageMetadata);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 1, 24, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 10, 24, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Module>(new Mp4WriterSink(mp4WriterSinkProps));
@@ -85,7 +85,7 @@ void write_metadata(std::string inFolderPath, std::string outFolderPath, std::st
 	fileReader->setNext(readerMuxer);
 	metadataReader->setNext(readerMuxer);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 1, fileReaderProps.fps, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 10, fileReaderProps.fps, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Module>(new Mp4WriterSink(mp4WriterSinkProps));

--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(setgetprops_jpeg)
 	LOG_ERROR << "processing folder <" << inFolderPath << ">";
 	p->run_all_threaded();
 
-	Test_Utils::sleep_for_seconds(70);
+	Test_Utils::sleep_for_seconds(20);
 
 	Mp4WriterSinkProps propschange = mp4WriterSink->getProps();
 	propschange.chunkTime = 2;
@@ -219,8 +219,8 @@ BOOST_AUTO_TEST_CASE(setgetprops_jpeg)
 
 BOOST_AUTO_TEST_CASE(h264_to_mp4v, *boost::unit_test::disabled())
 {
-	int width = 640;
-	int height = 360;
+	int width = 704;
+	int height = 576;
 
 	std::string inFolderPath = "./data/h264_data/";
 	std::string outFolderPath = "./data/testOutput/mp4_videos/h264_videos/";
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(h264_to_mp4v, *boost::unit_test::disabled())
 	LOG_ERROR << "processing folder <" << inFolderPath << ">";
 	p->run_all_threaded();
 
-	Test_Utils::sleep_for_seconds(2500);
+	Test_Utils::sleep_for_seconds(10);
 
 	p->stop();
 	p->term();
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(h264_to_mp4v_chunking)
 	LOG_ERROR << "processing folder <" << inFolderPath << ">";
 	p->run_all_threaded();
 
-	Test_Utils::sleep_for_seconds(250);
+	Test_Utils::sleep_for_seconds(130);
 
 	p->stop();
 	p->term();
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(h264_metadata, *boost::unit_test::disabled())
 
 	auto fileReaderProps = FileReaderModuleProps(inFolderPath, 0, -1);
 	fileReaderProps.fps = 24;
-	fileReaderProps.readLoop = true;
+	fileReaderProps.readLoop = false;
 
 	auto fileReader = boost::shared_ptr<Module>(new FileReaderModule(fileReaderProps));
 	auto encodedImageMetadata = framemetadata_sp(new H264Metadata(width, height));
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(parsenalu, *boost::unit_test::disabled())
 	int width = 640;
 	int height = 360;
 	
-	std::string inFolderPath = "./data/h264_data/";
+	std::string inFolderPath = "./data/h264_frames/";
 
 	auto fileReaderProps = FileReaderModuleProps(inFolderPath, 0, -1);
 	fileReaderProps.fps = 24;
@@ -407,11 +407,11 @@ BOOST_AUTO_TEST_CASE(parsenalu, *boost::unit_test::disabled())
 		fileReader->step();
 		auto frames = sink->pop();
 		auto frame = Module::getFrameByType(frames, FrameMetadata::FrameType::H264_DATA);
-		boost::asio::mutable_buffer frame1 = *(frame.get());
-		auto ret = H264Utils::parseNalu(frame1);
-		const_buffer spsBuff, ppsBuff, inFrame;
+		auto mFrameBuffer = const_buffer(frame->data(), frame->size());
+		auto ret = H264Utils::parseNalu(mFrameBuffer);
+		const_buffer spsBuff, ppsBuff;
 		short typeFound;
-		tie(typeFound, inFrame, spsBuff, ppsBuff) = ret;
+		tie(typeFound, spsBuff, ppsBuff) = ret;
 		auto spsBuffer = static_cast<const char*>(spsBuff.data());
 		auto ppsBuffer = static_cast<const char*>(ppsBuff.data());
 		
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(setgetprops_h264)
 	LOG_ERROR << "processing folder <" << inFolderPath << ">";
 	p->run_all_threaded();
 
-	Test_Utils::sleep_for_seconds(70);
+	Test_Utils::sleep_for_seconds(20);
 	
 	Mp4WriterSinkProps propschange = mp4WriterSink->getProps();
 	propschange.chunkTime = 2;


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**
parseNalu function fixed , now the function will take const const_buffer as argument so now incoming image wont get tampered. In the mp4Writer module for h264 case , whenever the path of file changed the last video got ended without waiting for an i-frame to arrive , fixed the issue.


Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix )

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
