### PR TITLE
Return Warning Fix

### DIFF
--- a/base/src/ArchiveSpaceManager.cpp
+++ b/base/src/ArchiveSpaceManager.cpp
@@ -66,6 +66,7 @@ public:
                 }
             }
         }
+        return _cam;
     };
 
     void manageDirectory()

--- a/base/src/MultimediaQueueXform.cpp
+++ b/base/src/MultimediaQueueXform.cpp
@@ -720,6 +720,7 @@ bool MultimediaQueueXform::handleCommand(Command::CommandType type, frame_sp& fr
 		}
 		return true;
 	}
+	return Module::handleCommand(type, frame);
 }
 
 bool MultimediaQueueXform::allowFrames(uint64_t& ts, uint64_t& te)


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**

The return warning for ArchiveSpaceManager and MultimediaQueueXForm is solved.

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
