### PR TITLE
Custom file name for a video feature and write timestamp in the video header

### DIFF
--- a/base/include/Mp4WriterSink.h
+++ b/base/include/Mp4WriterSink.h
@@ -13,7 +13,7 @@ public:
 	{
 		baseFolder = _baseFolder;
 		fps = _fps;
-		if (_chunkTime >= 1 && _chunkTime <= 60)
+		if ((_chunkTime >= 1 && _chunkTime <= 60) || (_chunkTime == UINT32_MAX))
 		{
 			chunkTime = _chunkTime;
 		}

--- a/base/include/Mp4WriterSink.h
+++ b/base/include/Mp4WriterSink.h
@@ -9,7 +9,7 @@ class DetailH264;
 class Mp4WriterSinkProps : public ModuleProps
 {
 public:
-	Mp4WriterSinkProps(uint32_t _chunkTime, uint32_t _syncTime, uint16_t _fps, std::string _baseFolder) : ModuleProps()
+	Mp4WriterSinkProps(uint32_t _chunkTime, uint32_t _syncTimeInSecs, uint16_t _fps, std::string _baseFolder) : ModuleProps()
 	{
 		baseFolder = _baseFolder;
 		fps = _fps;
@@ -19,11 +19,11 @@ public:
 		}
 		else
 		{
-			throw AIPException(AIP_FATAL, "ChuntTime should be within [1,60] minutes limit");
+			throw AIPException(AIP_FATAL, "ChuntTime should be within [1,60] minutes limit or UINT32_MAX");
 		}
-		if (_syncTime >= 1 && _syncTime <= 60)
+		if (_syncTimeInSecs >= 1 && _syncTimeInSecs <= 60)
 		{
-			syncTime = _syncTime;
+			syncTimeInSecs = _syncTimeInSecs;
 		}
 		else
 		{
@@ -35,7 +35,7 @@ public:
 	{
 		baseFolder = "./data/mp4_videos/";
 		chunkTime = 1; //minutes
-		syncTime = 1;
+		syncTimeInSecs = 1;
 		fps = 30;
 	}
 
@@ -44,13 +44,13 @@ public:
 		return ModuleProps::getSerializeSize() +
 			sizeof(baseFolder) +
 			sizeof(chunkTime) +
-			sizeof(syncTime) +
+			sizeof(syncTimeInSecs) +
 			sizeof(fps);
 	}
 
 	std::string baseFolder;
 	uint32_t chunkTime = 1;
-	uint32_t syncTime = 1;
+	uint32_t syncTimeInSecs = 1;
 	uint16_t fps = 30;
 private:
 	friend class boost::serialization::access;
@@ -61,7 +61,7 @@ private:
 		ar &boost::serialization::base_object<ModuleProps>(*this);
 		ar &baseFolder;
 		ar &chunkTime;
-		ar &syncTime;
+		ar &syncTimeInSecs;
 		ar &fps;
 	}
 };

--- a/base/include/Mp4WriterSinkUtils.h
+++ b/base/include/Mp4WriterSinkUtils.h
@@ -10,6 +10,7 @@ public:
 		boost::filesystem::path &relPath, std::string &mp4FileName, bool &syncFlag, std::string baseFolder, std::string& nextFrameFileName);
 	void parseTSH264(uint64_t& tm, uint32_t& chunkTimeInMinutes, uint32_t& syncTimeInSeconds,boost::filesystem::path& relPath,
 		std::string& mp4FileName, bool& syncFlag,short frameType, short naluType, std::string baseFolder, std::string& nextFrameFileName);
+	bool customNamedFileDirCheck(std::string baseFolder, uint32_t chunkTimeInMinutes, boost::filesystem::path relPath, std::string& nextFrameFileName);
 	std::string format_hrs(int &hr);
 	std::string format_2(int &min);
 	std::string filePath(boost::filesystem::path relPath, std::string mp4FileName, std::string baseFolder);

--- a/base/src/Mp4WriterSink.cpp
+++ b/base/src/Mp4WriterSink.cpp
@@ -26,7 +26,7 @@ public:
 
 	void setProps(Mp4WriterSinkProps& _props)
 	{
-		mProps.reset(new Mp4WriterSinkProps(_props.chunkTime, _props.syncTime, _props.fps, _props.baseFolder));
+		mProps.reset(new Mp4WriterSinkProps(_props.chunkTime, _props.syncTimeInSecs, _props.fps, _props.baseFolder));
 	}
 
 	~DetailAbs()
@@ -149,6 +149,17 @@ public:
 		return !mInputMetadata.get();
 	}
 
+	void addMetadataInVideoHeader(frame_sp inFrame)
+	{
+		if (!lastFrameTS)
+		{
+			/* \251sts -> ©sts */
+			std::string key = "\251sts";
+			std::string val = std::to_string(inFrame->timestamp);
+			mp4_mux_add_file_metadata(mux, key.c_str(), val.c_str());
+		}
+	}
+
 	boost::shared_ptr<Mp4WriterSinkProps> mProps;
 	bool mMetadataEnabled = false;
 	bool isKeyFrame;
@@ -230,7 +241,7 @@ bool DetailJpeg::write(frame_container& frames)
 	short naluType = 0;
 	std::string _nextFrameFileName;
 	mWriterSinkUtils.getFilenameForNextFrame(_nextFrameFileName, inJpegImageFrame->timestamp, mProps->baseFolder,
-		mProps->chunkTime, mProps->syncTime, syncFlag ,mFrameType, naluType);
+		mProps->chunkTime, mProps->syncTimeInSecs, syncFlag ,mFrameType, naluType);
 
 	if (_nextFrameFileName == "")
 	{
@@ -250,13 +261,7 @@ bool DetailJpeg::write(frame_container& frames)
 		syncFlag = false;
 	}
 
-	if (!lastFrameTS)
-	{
-		/* \251sts -> ©sts */
-		std::string key = "\251sts";
-		std::string val = std::to_string(inJpegImageFrame->timestamp);
-		mp4_mux_add_file_metadata(mux, key.c_str(), val.c_str());
-	}
+	addMetadataInVideoHeader(inJpegImageFrame);
 
 	mux_sample.buffer = static_cast<uint8_t*>(inJpegImageFrame->data());
 	mux_sample.len = inJpegImageFrame->size();
@@ -319,7 +324,7 @@ bool DetailH264::write(frame_container& frames)
 
 	std::string _nextFrameFileName;
 	mWriterSinkUtils.getFilenameForNextFrame(_nextFrameFileName,inH264ImageFrame->timestamp, mProps->baseFolder,
-		mProps->chunkTime, mProps->syncTime, syncFlag,mFrameType, typeFound);
+		mProps->chunkTime, mProps->syncTimeInSecs, syncFlag,mFrameType, typeFound);
 
 	if (_nextFrameFileName == "")
 	{
@@ -348,13 +353,7 @@ bool DetailH264::write(frame_container& frames)
 		isKeyFrame = false;
 	}
 
-	if (!lastFrameTS)
-	{
-		/* \251sts -> ©sts */
-		std::string key = "\251sts";
-		std::string val = std::to_string(inH264ImageFrame->timestamp);
-		mp4_mux_add_file_metadata(mux, key.c_str(), val.c_str());
-	}
+	addMetadataInVideoHeader(inH264ImageFrame);
 
 	mux_sample.buffer = static_cast<uint8_t*>(inH264ImageFrame->data());
 	mux_sample.len = inH264ImageFrame->size();
@@ -536,7 +535,7 @@ bool Mp4WriterSink::processEOS(string& pinId)
 
 Mp4WriterSinkProps Mp4WriterSink::getProps()
 {
-	auto tempProps = Mp4WriterSinkProps(mDetail->mProps->chunkTime, mDetail->mProps->syncTime, mDetail->mProps->fps, mDetail->mProps->baseFolder);
+	auto tempProps = Mp4WriterSinkProps(mDetail->mProps->chunkTime, mDetail->mProps->syncTimeInSecs, mDetail->mProps->fps, mDetail->mProps->baseFolder);
 	fillProps(tempProps);
 	return tempProps;
 }

--- a/base/src/Mp4WriterSink.cpp
+++ b/base/src/Mp4WriterSink.cpp
@@ -249,6 +249,15 @@ bool DetailJpeg::write(frame_container& frames)
 		mp4_mux_sync(mux);
 		syncFlag = false;
 	}
+
+	if (!lastFrameTS)
+	{
+		/* \251sts -> ©sts */
+		std::string key = "\251sts";
+		std::string val = std::to_string(inJpegImageFrame->timestamp);
+		mp4_mux_add_file_metadata(mux, key.c_str(), val.c_str());
+	}
+
 	mux_sample.buffer = static_cast<uint8_t*>(inJpegImageFrame->data());
 	mux_sample.len = inJpegImageFrame->size();
 	mux_sample.sync = 0;
@@ -338,6 +347,15 @@ bool DetailH264::write(frame_container& frames)
 	{
 		isKeyFrame = false;
 	}
+
+	if (!lastFrameTS)
+	{
+		/* \251sts -> ©sts */
+		std::string key = "\251sts";
+		std::string val = std::to_string(inH264ImageFrame->timestamp);
+		mp4_mux_add_file_metadata(mux, key.c_str(), val.c_str());
+	}
+
 	mux_sample.buffer = static_cast<uint8_t*>(inH264ImageFrame->data());
 	mux_sample.len = inH264ImageFrame->size();
 	mux_sample.sync = isKeyFrame ? 1 : 0;

--- a/base/src/Mp4WriterSinkUtils.cpp
+++ b/base/src/Mp4WriterSinkUtils.cpp
@@ -94,7 +94,6 @@ void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes,
 	// cache new values
 	currentFolder = baseFolder;
 	lastVideoTS = t;
-	lastVideoFolderPath = relPath;
 	lastVideoMinute = tm.tm_min;
 
 	if (boost::filesystem::extension(baseFolder) == ".mp4")
@@ -131,6 +130,7 @@ void Mp4WriterSinkUtils::parseTSJpeg(uint64_t &ts, uint32_t &chunkTimeInMinutes,
 	std::string yyyymmdd = std::to_string(1900 + tm.tm_year) + format_2(tm.tm_mon) + format_2(tm.tm_mday);
 	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
 	mp4FileName = std::to_string(ts) + ".mp4";
+	lastVideoFolderPath = relPath;
 
 	lastVideoName = mp4FileName;
 	
@@ -179,7 +179,6 @@ void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes,
 	// cache new values
 	currentFolder = baseFolder;
 	lastVideoTS = t;
-	lastVideoFolderPath = relPath;
 	lastVideoMinute = tm.tm_min;
 
 	if (boost::filesystem::extension(baseFolder) == ".mp4")
@@ -217,6 +216,7 @@ void Mp4WriterSinkUtils::parseTSH264(uint64_t& ts, uint32_t& chunkTimeInMinutes,
 	relPath = boost::filesystem::path(yyyymmdd) / format_hrs(tm.tm_hour);
 	mp4FileName = std::to_string(ts) + ".mp4";
 	lastVideoName = mp4FileName;
+	lastVideoFolderPath = relPath;
 
 	nextFrameFileName = filePath(relPath, mp4FileName, baseFolder);
 	tempNextFrameFileName = nextFrameFileName;

--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(jpg_mono_8_to_mp4v_metadata)
 
 	std::string inFolderPath = "./data/re3_filtered_mono";
 	std::string outFolderPath = "./data/testOutput/mp4_videos/mono_metadata_video/";
-	std::string metadataPath = "./data/metadata/";
+	std::string metadataPath = "./data/Metadata/";
 
 	write_metadata(inFolderPath, outFolderPath, metadataPath, width, height, 30);
 }
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(jpeg_metadata)
 
 	std::string inFolderPath = "./data/re3_filtered";
 	std::string outFolderPath = "./data/testOutput/mp4_videos/rgb_metadata_video";
-	std::string metadataPath = "./data/metadata/";
+	std::string metadataPath = "./data/Metadata/";
 
 	write_metadata(inFolderPath, outFolderPath, metadataPath, width, height, fps);
 }
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(h264_metadata, *boost::unit_test::disabled())
 
 	std::string inFolderPath = "./data/h264_data/";
 	std::string outFolderPath = "./data/testOutput/mp4_videos/h264_metadata/";
-	std::string metadataPath = "./data/metadata/";
+	std::string metadataPath = "./data/Metadata/";
 
 	LoggerProps loggerProps;
 	loggerProps.logLevel = boost::log::trivial::severity_level::info;

--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -35,7 +35,7 @@ void writeH264(bool readLoop, int sleepSeconds, std::string outFolderPath, int c
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(width, height));
 	fileReader->addOutputPin(h264ImageMetadata);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(chunkTime, 1, 100, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(chunkTime, 10, 100, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Module>(new Mp4WriterSink(mp4WriterSinkProps));
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(jpg_mono_8_to_mp4v)
 	write(inFolderPath, outFolderPath, width, height);
 }
 
-BOOST_AUTO_TEST_CASE(jpg_mono_8_to_mp4v_metadata, *boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(jpg_mono_8_to_mp4v_metadata)
 {
 	int width = 1280;
 	int height = 720;
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(jpg_mono_8_to_mp4v_metadata, *boost::unit_test::disabled())
 	write_metadata(inFolderPath, outFolderPath, metadataPath, width, height, 30);
 }
 
-BOOST_AUTO_TEST_CASE(jpeg_metadata, *boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(jpeg_metadata)
 {
 	/* metadata, RGB, 24bpp, 960x480 */
 	int width = 1280;
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(setgetprops_jpeg)
 	auto encodedImageMetadata = framemetadata_sp(new EncodedImageMetadata(width, height));
 	fileReader->addOutputPin(encodedImageMetadata);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 1, 30, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 10, 30, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Mp4WriterSink>(new Mp4WriterSink(mp4WriterSinkProps));
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(setgetprops_jpeg)
 	p.reset();
 }
 
-BOOST_AUTO_TEST_CASE(h264_to_mp4v, *boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(h264_to_mp4v)
 {
 	std::string outFolderPath = "./data/testOutput/mp4_videos/h264_videos/";
 	writeH264(false, 10, outFolderPath);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(h264_metadata, *boost::unit_test::disabled())
 	fileReader->setNext(readerMuxer);
 	metadataReader->setNext(readerMuxer);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 1, fileReaderProps.fps, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 10, fileReaderProps.fps, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Module>(new Mp4WriterSink(mp4WriterSinkProps));
@@ -339,12 +339,12 @@ BOOST_AUTO_TEST_CASE(h264_metadata, *boost::unit_test::disabled())
 	p.reset();
 }
 
-BOOST_AUTO_TEST_CASE(parsenalu, *boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(parsenalu)
 {
 	int width = 640;
 	int height = 360;
 	
-	std::string inFolderPath = "./data/h264_frames/";
+	std::string inFolderPath = "./data/h264_frames/Raw_YUV420_640x360_????.h264";
 
 	auto fileReaderProps = FileReaderModuleProps(inFolderPath, 0, -1);
 	fileReaderProps.fps = 24;
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE(setgetprops_h264)
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(width, height));
 	fileReader->addOutputPin(h264ImageMetadata);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 1, 30, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(1, 10, 30, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Mp4WriterSink>(new Mp4WriterSink(mp4WriterSinkProps));
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(single_file_given_name_jpeg)
 	int height = 720;
 
 	std::string inFolderPath = "./data/re3_filtered_mono";
-	std::string outFolderPath = "./data/testOutput/mp4_videos/mono_8bpp/apra.mp4";
+	std::string outFolderPath = "./data/testOutput/mp4_videos/apra.mp4";
 
 	write(inFolderPath, outFolderPath, width, height, UINT32_MAX);
 }

--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -71,7 +71,7 @@ void write(std::string inFolderPath, std::string outFolderPath, int width, int h
 
 	auto fileReaderProps = FileReaderModuleProps(inFolderPath, 0, -1);
 	fileReaderProps.fps = 24;
-	fileReaderProps.readLoop = true;
+	fileReaderProps.readLoop = false;
 
 	auto fileReader = boost::shared_ptr<Module>(new FileReaderModule(fileReaderProps));
 	auto encodedImageMetadata = framemetadata_sp(new EncodedImageMetadata(width, height));
@@ -97,7 +97,7 @@ void write(std::string inFolderPath, std::string outFolderPath, int width, int h
 	LOG_ERROR << "processing folder <" << inFolderPath << ">";
 	p->run_all_threaded();
 
-	Test_Utils::sleep_for_seconds(120);
+	Test_Utils::sleep_for_seconds(15);
 
 	p->stop();
 	p->term();
@@ -163,10 +163,10 @@ void write_metadata(std::string inFolderPath, std::string outFolderPath, std::st
 
 BOOST_AUTO_TEST_CASE(jpg_rgb_24_to_mp4v)
 {
-	int width = 960;
-	int height = 480;
+	int width = 1280;
+	int height = 720;
 
-	std::string inFolderPath = "./data/streamer_frames";
+	std::string inFolderPath = "./data/re3_filtered";
 	std::string outFolderPath = "./data/testOutput/mp4_videos/rgb_24bpp/";
 
 	write(inFolderPath, outFolderPath, width, height);

--- a/data/Metadata/metadata0.txt
+++ b/data/Metadata/metadata0.txt
@@ -1,1 +1,1 @@
-ApraPipes_1
+ApraPipes_0

--- a/data/Metadata/metadata0.txt
+++ b/data/Metadata/metadata0.txt
@@ -1,0 +1,1 @@
+ApraPipes_1

--- a/data/Metadata/metadata1.txt
+++ b/data/Metadata/metadata1.txt
@@ -1,0 +1,1 @@
+ApraPipes_1

--- a/data/Metadata/metadata2.txt
+++ b/data/Metadata/metadata2.txt
@@ -1,0 +1,1 @@
+ApraPipes_2

--- a/data/Metadata/metadata3.txt
+++ b/data/Metadata/metadata3.txt
@@ -1,0 +1,1 @@
+ApraPipes_3

--- a/data/Metadata/metadata4.txt
+++ b/data/Metadata/metadata4.txt
@@ -1,0 +1,1 @@
+ApraPipes_4


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description : We can now write a video with any custom name given by the user.

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Feature)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
