### PR TITLE
EnhancedRawImagePlanarMetadata

### DIFF
--- a/base/include/RawImagePlanarMetadata.h
+++ b/base/include/RawImagePlanarMetadata.h
@@ -12,7 +12,6 @@ public:
 	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, size_t alignLength, int _depth, MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
 	{
 		size_t _step[4] = {0, 0, 0, 0};
-		size_t nextPtrOffset[4] = { 0,0,0,0 };
 
 		switch (_imageType)
 		{
@@ -49,7 +48,6 @@ public:
 
 	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, size_t _step[4], int _depth, MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
 	{
-		size_t nextPtrOffset[4] = { 0,0,0,0 };
 		initData(_width, _height, _imageType, _step, _depth, nextPtrOffset);
 	}
 

--- a/base/include/RawImagePlanarMetadata.h
+++ b/base/include/RawImagePlanarMetadata.h
@@ -43,12 +43,17 @@ public:
 			_step[i] = _step[i] * elemSize;
 		}
 
-		initData(_width, _height, _imageType, _step, _depth);
+		initData(_width, _height, _imageType, _step, _depth, nextPtrOffset);
 	}
 
 	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, size_t _step[4], int _depth, MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
 	{
-		initData(_width, _height, _imageType, _step, _depth);
+		initData(_width, _height, _imageType, _step, _depth, nextPtrOffset);
+	}
+
+	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, int _depth, size_t _step[4], size_t _nextPtrOffset[4], MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
+	{
+		initData(_width, _height, _imageType, _step, _depth, _nextPtrOffset);
 	}
 
 	void reset()
@@ -146,16 +151,26 @@ protected:
 		dataSize = 0;
 		for (auto i = 0; i < channels; i++)
 		{
-			nextPtrOffset[i] = dataSize;
-			dataSize += step[i] * height[i];
+			if (nextPtrOffset[i] == NOT_SET_NUM)
+			{
+				nextPtrOffset[i] = dataSize;
+				dataSize += step[i] * height[i];
+			}
+
+			else {}
 		}
 	}
 
-	void initData(int _width, int _height, ImageMetadata::ImageType _imageType, size_t _step[4], int _depth)
+	void initData(int _width, int _height, ImageMetadata::ImageType _imageType, size_t _step[4], int _depth, size_t _nextPtrOffset[4])
 	{
 		channels = 3;
 		depth = _depth;
 		imageType = _imageType;
+
+		for (auto i = 0; i < channels; i++)
+		{
+			nextPtrOffset[i] = _nextPtrOffset[i];
+		}
 
 		for (auto i = 0; i < channels; i++)
 		{

--- a/base/include/RawImagePlanarMetadata.h
+++ b/base/include/RawImagePlanarMetadata.h
@@ -12,6 +12,7 @@ public:
 	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, size_t alignLength, int _depth, MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
 	{
 		size_t _step[4] = {0, 0, 0, 0};
+		size_t nextPtrOffset[4] = { 0,0,0,0 };
 
 		switch (_imageType)
 		{
@@ -48,6 +49,7 @@ public:
 
 	RawImagePlanarMetadata(int _width, int _height, ImageMetadata::ImageType _imageType, size_t _step[4], int _depth, MemType _memType = MemType::HOST) : FrameMetadata(FrameType::RAW_IMAGE_PLANAR, _memType)
 	{
+		size_t nextPtrOffset[4] = { 0,0,0,0 };
 		initData(_width, _height, _imageType, _step, _depth, nextPtrOffset);
 	}
 

--- a/base/include/RawImagePlanarMetadata.h
+++ b/base/include/RawImagePlanarMetadata.h
@@ -156,8 +156,6 @@ protected:
 				nextPtrOffset[i] = dataSize;
 				dataSize += step[i] * height[i];
 			}
-
-			else {}
 		}
 	}
 
@@ -170,10 +168,6 @@ protected:
 		for (auto i = 0; i < channels; i++)
 		{
 			nextPtrOffset[i] = _nextPtrOffset[i];
-		}
-
-		for (auto i = 0; i < channels; i++)
-		{
 			step[i] = _step[i];
 		}
 

--- a/base/test/imagemetadata_tests.cpp
+++ b/base/test/imagemetadata_tests.cpp
@@ -191,4 +191,30 @@ BOOST_AUTO_TEST_CASE(rawimageplanar_yuv444)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(rawplanar_offset)
+{
+	int width = 1920;
+	int height = 1080;
+	size_t step[4] = { 2048, 2048, 2048 };
+	size_t mnextPtrOffset[4] = { 0, 2000,350, 0 };
+	int channels = 3;
+	int depth = CV_8U;
+
+	{
+		auto metadata = framemetadata_sp(new RawImagePlanarMetadata(width, height, ImageMetadata::YUV444,depth,step, mnextPtrOffset, FrameMetadata::HOST));
+
+		auto ptr = FrameMetadataFactory::downcast<RawImagePlanarMetadata>(metadata);
+		for (auto i = 0; i < channels; i++)
+		{
+			BOOST_TEST(ptr->getWidth(i) == width);
+			BOOST_TEST(ptr->getHeight(i) == height);
+			BOOST_TEST(ptr->getStep(i) == step[i]);
+			BOOST_TEST(ptr->getNextPtrOffset(i) == mnextPtrOffset[i]);
+		}
+		BOOST_TEST(ptr->getChannels() == channels);
+		BOOST_TEST(ptr->getDataSize() == 0);
+	}
+
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #208

**Description**
updated RawImagePlanarMetadata which takes a array of four integers in the constructor and  use these pointers instead of calculating the offsets itself.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

No

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
