### PR TITLE
Enhanced DMAllocator setMetadata

### DIFF
--- a/base/include/DMAAllocator.h
+++ b/base/include/DMAAllocator.h
@@ -98,7 +98,7 @@ public:
         }
     }
 
-    static void setMetadata(framemetadata_sp &metadata, int width, int height, ImageMetadata::ImageType imageType)
+    static void setMetadata(framemetadata_sp &metadata, int width, int height, ImageMetadata::ImageType imageType,size_t pitchValues[4] = nullptr, size_t offsetValues[4] = nullptr)
     {
         auto eglDisplay = ApraEGLDisplay::getEGLDisplay();
         auto colorFormat = getColorFormat(imageType);
@@ -144,6 +144,10 @@ public:
             auto inputRawMetadata = FrameMetadataFactory::downcast<RawImageMetadata>(metadata);
             RawImageMetadata rawMetadata(width, height, imageType, type, fdParams.pitch[0], CV_8U, FrameMetadata::MemType::DMABUF, false);
             inputRawMetadata->setData(rawMetadata);
+            if(pitchValues != nullptr)
+            {
+              pitchValues[0] = fdParams.pitch[0];
+            }
         }
         break;
         case FrameMetadata::FrameType::RAW_IMAGE_PLANAR:
@@ -153,6 +157,14 @@ public:
             for (auto i = 0; i < fdParams.num_planes; i++)
             {
                 step[i] = fdParams.pitch[i];
+                if(pitchValues != nullptr)
+                {
+                  pitchValues[i] = fdParams.pitch[i];
+                }
+                if(offsetValues != nullptr)
+                {
+                  offsetValues[i] = fdParams.offset[i];
+                }
             }
             RawImagePlanarMetadata rawMetadata(width, height, imageType, step, CV_8U, FrameMetadata::MemType::DMABUF);
             inputRawMetadata->setData(rawMetadata);

--- a/base/test/frame_factory_test_dma.cpp
+++ b/base/test/frame_factory_test_dma.cpp
@@ -3,6 +3,7 @@
 #include "RawImageMetadata.h"
 #include "RawImagePlanarMetadata.h"
 #include "DMAFDWrapper.h"
+#include "DMAAllocator.h"
 
 #include <fstream>
 
@@ -184,6 +185,49 @@ BOOST_AUTO_TEST_CASE(save_rgba)
         }
         frames.push_back(frame);
     }
+}
+
+BOOST_AUTO_TEST_CASE(setMetadata_rawimage)
+{
+    uint32_t width = 1280;
+    uint32_t height = 720;
+    size_t size = width * height * 4;
+    size_t pitch[4] = {0,0,0,0};
+    auto metadata = framemetadata_sp(new RawImageMetadata(width, height, ImageMetadata::ImageType::RGBA, CV_8UC4, size_t(0), CV_8U, FrameMetadata::MemType::DMABUF, true));
+    DMAAllocator::setMetadata(metadata,1280,720,ImageMetadata::ImageType::RGBA,pitch);
+    size_t mPitch[1] = { pitch[0] };
+    std::cout << "mPitch: " << mPitch[0] << std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(setMetadata_rawplanarimage)
+{
+    uint32_t width = 1280;
+    uint32_t height = 720;
+    size_t size = width * height * 4;
+    size_t pitch[4] = {0,0,0,0};
+    size_t offset[4] = {0,0,0,0};
+    auto metadata = framemetadata_sp(new RawImagePlanarMetadata(width, height, ImageMetadata::ImageType::YUV420, size_t(0), CV_8U, FrameMetadata::MemType::DMABUF));
+    DMAAllocator::setMetadata(metadata,1280,720,ImageMetadata::ImageType::YUV420,pitch,offset);
+    size_t mPitch[4];
+    size_t mOffset[4];
+    for (int i = 0; i < 4; i++)
+    {
+      mOffset[i] = offset[i];
+      mPitch[i]  = pitch[i];
+    }
+    std::cout << "mPitch values: ";
+    for (int i = 0; i < 4; i++)
+    {
+      std::cout << mPitch[i] << " ";
+    }
+    std::cout << std::endl;
+
+    std::cout << "mOffset values: ";
+    for (int i = 0; i < 4; i++)
+    {
+      std::cout << mOffset[i] << " ";
+    }
+    std::cout << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/frame_factory_test_dma.cpp
+++ b/base/test/frame_factory_test_dma.cpp
@@ -4,6 +4,7 @@
 #include "RawImagePlanarMetadata.h"
 #include "DMAFDWrapper.h"
 #include "DMAAllocator.h"
+#include "Logger.h"
 
 #include <fstream>
 
@@ -189,6 +190,10 @@ BOOST_AUTO_TEST_CASE(save_rgba)
 
 BOOST_AUTO_TEST_CASE(setMetadata_rawimage)
 {
+    LoggerProps logprops;
+	logprops.logLevel = boost::log::trivial::severity_level::info;
+	Logger::initLogger(logprops);
+
     uint32_t width = 1280;
     uint32_t height = 720;
     size_t size = width * height * 4;
@@ -196,11 +201,15 @@ BOOST_AUTO_TEST_CASE(setMetadata_rawimage)
     auto metadata = framemetadata_sp(new RawImageMetadata(width, height, ImageMetadata::ImageType::RGBA, CV_8UC4, size_t(0), CV_8U, FrameMetadata::MemType::DMABUF, true));
     DMAAllocator::setMetadata(metadata,1280,720,ImageMetadata::ImageType::RGBA,pitch);
     size_t mPitch[1] = { pitch[0] };
-    std::cout << "mPitch: " << mPitch[0] << std::endl;
+    LOG_INFO << "mPitch: " << mPitch[0];
 }
 
 BOOST_AUTO_TEST_CASE(setMetadata_rawplanarimage)
 {
+    LoggerProps logprops;
+	logprops.logLevel = boost::log::trivial::severity_level::info;
+	Logger::initLogger(logprops);
+
     uint32_t width = 1280;
     uint32_t height = 720;
     size_t size = width * height * 4;
@@ -215,19 +224,17 @@ BOOST_AUTO_TEST_CASE(setMetadata_rawplanarimage)
       mOffset[i] = offset[i];
       mPitch[i]  = pitch[i];
     }
-    std::cout << "mPitch values: ";
+    LOG_INFO << "mPitch values: ";
     for (int i = 0; i < 4; i++)
     {
-      std::cout << mPitch[i] << " ";
+      LOG_INFO << mPitch[i] << " ";
     }
-    std::cout << std::endl;
-
-    std::cout << "mOffset values: ";
+    
+    LOG_INFO << "mOffset values: ";
     for (int i = 0; i < 4; i++)
     {
-      std::cout << mOffset[i] << " ";
+      LOG_INFO << mOffset[i] << " ";
     }
-    std::cout << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #237 

**Description**

added two more arguments pitch,offset to the DMAAllocator setMetadata whose default values will be null , if we pass those with some random values and call DMAAllocator setMetadata API i will return correct offset and pitch values for respective DMA buffer

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?
NO

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
