### PR TITLE
Added cuda compute cap precondition to cudaMemcpyTests

### DIFF
--- a/base/test/cudamemcopy_tests.cpp
+++ b/base/test/cudamemcopy_tests.cpp
@@ -14,7 +14,7 @@
 
 BOOST_AUTO_TEST_SUITE(cudamemcopy_tests)
 
-BOOST_AUTO_TEST_CASE(isCudaSupported)
+BOOST_AUTO_TEST_CASE(isCudaSupported, * utf::precondition(if_compute_cap_supported()))
 {
 	BOOST_TEST(CudaUtils::isCudaSupported());
 }


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**
The cuda tests fail on linux cuda self host machine due to the machine's low cuda compute capability , so to avoid the failure added compute cap precondition in the CudaMemcpyTest

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
