### PR TITLE
Fixed the H264Decoder not terminating issue

### DIFF
--- a/base/src/H264Decoder.cpp
+++ b/base/src/H264Decoder.cpp
@@ -57,6 +57,11 @@ public:
 	{
 		helper->process(frame);
 	}
+
+	void closeAllThreads(frame_sp eosFrame)
+	{
+		helper->closeAllThreads(eosFrame);
+	}
 public:
 	int mWidth;
 	int mHeight;
@@ -138,8 +143,12 @@ bool H264Decoder::init()
 
 bool H264Decoder::term()
 {
-	mDetail.reset();
+#ifdef ARM64
+	auto eosFrame = frame_sp(new EoSFrame());
+	mDetail->closeAllThreads(eosFrame);
+#endif
 
+	mDetail.reset();
 	return Module::term();
 }
 

--- a/base/src/H264DecoderV4L2Helper.cpp
+++ b/base/src/H264DecoderV4L2Helper.cpp
@@ -1385,7 +1385,7 @@ int h264DecoderV4L2Helper::process(frame_sp inputFrame)
     }
     return true;
 }
-h264DecoderV4L2Helper::~h264DecoderV4L2Helper() 
+void h264DecoderV4L2Helper::closeAllThreads() 
 {
     if (ctx.fd != -1)
     {

--- a/base/src/H264DecoderV4L2Helper.h
+++ b/base/src/H264DecoderV4L2Helper.h
@@ -147,7 +147,7 @@ public:
      * Refer to [V4L2 Video Decoder](group__V4L2Dec.html) for more information on the decoder.
      */
     h264DecoderV4L2Helper() {}
-    ~h264DecoderV4L2Helper(); //
+    ~h264DecoderV4L2Helper() {};
     typedef struct
     {
         uint32_t decode_pixfmt;
@@ -385,6 +385,7 @@ public:
 
     bool init(std::function<void(frame_sp &)> send, std::function<frame_sp()> makeFrame);
 
+    void closeAllThreads(frame_sp eosFrame);
 protected:
     boost::shared_ptr<Buffer> mBuffer;
     context_t ctx;


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #251 

**Description**
This PR fixes the bug where the H264DecoderV4L2 was not terminating and was getting stuck. The decoder needed a end of stream frame to close the pThread . 

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
