### PR TITLE
vcpkg build fix 

### DIFF
--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -45,31 +45,31 @@
         "libmount"
       ],
         "platform": "(linux \u0026 x64)",
-      "$reason": "skip linux:arm64 and windows"
-    },
-    {
-      "name": "glib",
-      "default-features": true,
-      "platform": "windows"
-    },
-    {
-      "name": "hiredis",
-      "platform": "!arm64"
-    },
-    {
-      "name": "redis-plus-plus",
-      "platform": "!arm64"
-    },
-    {
-      "name": "re",
-      "platform": "!windows"
-    },
-    {
-      "name": "baresip",
-      "platform": "!windows"
-    },
-    {
-      "name": "libmp4"
-    }
-  ]
-}
+        "$reason": "skip linux:arm64 and windows"
+      },
+      {
+        "name": "glib",
+        "default-features": true,
+        "platform": "windows"
+      },
+      {
+        "name": "hiredis",
+        "platform": "!arm64"
+      },
+      {
+        "name": "redis-plus-plus",
+        "platform": "!arm64"
+      },
+      {
+        "name": "re",
+        "platform": "!windows"
+      },
+      {
+        "name": "baresip",
+        "platform": "!windows"
+      },
+      {
+        "name": "libmp4"
+      }
+    ]
+  }

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "b0053dfa8bbaabd1cfc602b27d3cf7295987a073",
+  "builtin-baseline": "6baca0fccea3ace7e51f44d49f69696a9ed52b31",
   "dependencies": [
     {
       "name": "opencv4",
@@ -45,31 +45,31 @@
         "libmount"
       ],
         "platform": "(linux \u0026 x64)",
-        "$reason": "skip linux:arm64 and windows"
-      },
-      {
-        "name": "glib",
-        "default-features": true,
-        "platform": "windows"
-      },
-      {
-        "name": "hiredis",
-        "platform": "!arm64"
-      },
-      {
-        "name": "redis-plus-plus",
-        "platform": "!arm64"
-      },
-      {
-        "name": "re",
-        "platform": "!windows"
-      },
-      {
-        "name": "baresip",
-        "platform": "!windows"
-      },
-      {
-        "name": "libmp4"
-      }
-    ]
-  }
+      "$reason": "skip linux:arm64 and windows"
+    },
+    {
+      "name": "glib",
+      "default-features": true,
+      "platform": "windows"
+    },
+    {
+      "name": "hiredis",
+      "platform": "!arm64"
+    },
+    {
+      "name": "redis-plus-plus",
+      "platform": "!arm64"
+    },
+    {
+      "name": "re",
+      "platform": "!windows"
+    },
+    {
+      "name": "baresip",
+      "platform": "!windows"
+    },
+    {
+      "name": "libmp4"
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

This PR fixes the vcpkg build of baresip. The issue of hardcoded path for baresip to find re is resolved. 

**Type**

Type Choose one: Bug fix 

