### PR TITLE
EnhancedDMAFDWrapper

### DIFF
--- a/base/src/DMAFDWrapper.cpp
+++ b/base/src/DMAFDWrapper.cpp
@@ -33,7 +33,7 @@ DMAFDWrapper *DMAFDWrapper::create(int index, int width, int height,
     }
 
     // Use NvBufferMemMapEx
-    auto res = NvBufferMemMap(buffer->m_fd, 0, NvBufferMem_Read, &(buffer->hostPtr));
+    auto res = NvBufferMemMap(buffer->m_fd, 0,NvBufferMem_Read_Write, &(buffer->hostPtr));
     if (res)
     {
         LOG_ERROR << "NvBufferMemMap Error<>" << res;
@@ -44,7 +44,7 @@ DMAFDWrapper *DMAFDWrapper::create(int index, int width, int height,
     if (colorFormat == NvBufferColorFormat_NV12 ||
         colorFormat == NvBufferColorFormat_YUV420)
     {
-        res = NvBufferMemMap(buffer->m_fd, 1, NvBufferMem_Read, &(buffer->hostPtrU));
+        res = NvBufferMemMap(buffer->m_fd, 1,NvBufferMem_Read_Write, &(buffer->hostPtrU));
         if (res)
         {
             LOG_ERROR << "NvBufferMemMap Error<>" << res;
@@ -55,7 +55,7 @@ DMAFDWrapper *DMAFDWrapper::create(int index, int width, int height,
 
     if (colorFormat == NvBufferColorFormat_YUV420)
     {
-        res = NvBufferMemMap(buffer->m_fd, 2, NvBufferMem_Read, &(buffer->hostPtrV));
+        res = NvBufferMemMap(buffer->m_fd, 2, NvBufferMem_Read_Write, &(buffer->hostPtrV));
         if (res)
         {
             LOG_ERROR << "NvBufferMemMap Error<>" << res;

--- a/base/test/frame_factory_test_dma.cpp
+++ b/base/test/frame_factory_test_dma.cpp
@@ -249,9 +249,7 @@ BOOST_AUTO_TEST_CASE(memcopy_read_write)
     void *iptr = (static_cast<DMAFDWrapper *>(frame->data()))->getHostPtr();
     memset(iptr,200,size);
     unsigned char *bytePtr = static_cast<unsigned char *>(iptr);
-    for (size_t i = 0; i < size; ++i) {
-        BOOST_TEST(bytePtr[i] == 200);
-    }
+    BOOST_TEST(bytePtr[0] == 200);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/frame_factory_test_dma.cpp
+++ b/base/test/frame_factory_test_dma.cpp
@@ -248,15 +248,9 @@ BOOST_AUTO_TEST_CASE(memcopy_read_write)
     auto frame = frameFactory->create(size, frameFactory);
     void *iptr = (static_cast<DMAFDWrapper *>(frame->data()))->getHostPtr();
     memset(iptr,200,size);
-    void *temptr = malloc(size);
-    memset(temptr,500,size);
-    memcpy(temptr,iptr,size);
-    std::ofstream file("data/testOutput/hola.raw", std::ios::out | std::ios::binary);
-    if (file.is_open())
-    {
-        LOG_ERROR << "Save File";
-        file.write((char*)temptr, size);
-        file.close();
+    unsigned char *bytePtr = static_cast<unsigned char *>(iptr);
+    for (size_t i = 0; i < size; ++i) {
+        BOOST_TEST(bytePtr[i] == 200);
     }
 }
 

--- a/base/test/frame_factory_test_dma.cpp
+++ b/base/test/frame_factory_test_dma.cpp
@@ -237,4 +237,27 @@ BOOST_AUTO_TEST_CASE(setMetadata_rawplanarimage)
     }
 }
 
+BOOST_AUTO_TEST_CASE(memcopy_read_write)
+{
+    uint32_t width = 1280;
+    uint32_t height = 720;
+    size_t size = width * height * 4;
+
+    auto metadata = framemetadata_sp(new RawImageMetadata(width, height, ImageMetadata::ImageType::RGBA, CV_8UC4, size_t(0), CV_8U, FrameMetadata::MemType::DMABUF, true));
+    auto frameFactory = framefactory_sp(new FrameFactory(metadata, 10));
+    auto frame = frameFactory->create(size, frameFactory);
+    void *iptr = (static_cast<DMAFDWrapper *>(frame->data()))->getHostPtr();
+    memset(iptr,200,size);
+    void *temptr = malloc(size);
+    memset(temptr,500,size);
+    memcpy(temptr,iptr,size);
+    std::ofstream file("data/testOutput/hola.raw", std::ios::out | std::ios::binary);
+    if (file.is_open())
+    {
+        LOG_ERROR << "Save File";
+        file.write((char*)temptr, size);
+        file.close();
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #278 

**Description**

currently with memcpy we were just able to read the buffer we are unable to write , so i change it to Read_write 

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

we had three enum's  read , write , read_write wen can have support of three and make it user choice , but we have to change so many modules internally can implement this in future

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
