### PR TITLE
GenericRendererModule

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -528,6 +528,7 @@ SET(UT_FILES
 	test/jpegdecodercv_tests.cpp
 	test/Imageresizecv_tests.cpp
 	test/faciallandmarkscv_tests.cpp
+	test/imageviewermodule_tests.cpp
 	test/ImageEncodeCV_tests.cpp
 	test/rotatecv_tests.cpp
 	test/affinetransform_tests.cpp

--- a/base/include/ImageViewerModule.h
+++ b/base/include/ImageViewerModule.h
@@ -9,37 +9,38 @@ class DetailImageviewer;
 class ImageViewerModuleProps : public ModuleProps
 {
 public:
-	ImageViewerModuleProps(const string& _strTitle) : ModuleProps()
+	ImageViewerModuleProps(const string &_strTitle) : ModuleProps()
 	{
 		strTitle = _strTitle;
 	}
 
-	ImageViewerModuleProps(uint32_t _x_offset,uint32_t _y_offset, uint32_t _width, uint32_t _height) : ModuleProps()
+	ImageViewerModuleProps(uint32_t _x_offset, uint32_t _y_offset, uint32_t _width, uint32_t _height, bool _displayOnTop = true) : ModuleProps()
 	{
-        x_offset = _x_offset;
-        y_offset = _y_offset;
+		x_offset = _x_offset;
+		y_offset = _y_offset;
 		height = _height;
 		width = _width;
+		displayOnTop = _displayOnTop ? 1 : 0;
 	}
-	ImageViewerModuleProps(uint32_t _x_offset,uint32_t _y_offset,bool _displayOnTop = true) : ModuleProps()
+	ImageViewerModuleProps(uint32_t _x_offset, uint32_t _y_offset, bool _displayOnTop = true) : ModuleProps()
 	{
-        x_offset = _x_offset;
-        y_offset = _y_offset;
+		x_offset = _x_offset;
+		y_offset = _y_offset;
 		height = 0;
 		width = 0;
 		displayOnTop = _displayOnTop ? 1 : 0;
 	}
 
-    uint32_t x_offset;
-    uint32_t y_offset;
+	uint32_t x_offset;
+	uint32_t y_offset;
 	uint32_t height;
 	uint32_t width;
 	bool displayOnTop;
-
 	string strTitle;
 };
 
-class ImageViewerModule : public Module {
+class ImageViewerModule : public Module
+{
 public:
 	ImageViewerModule(ImageViewerModuleProps _props);
 	virtual ~ImageViewerModule();
@@ -47,13 +48,14 @@ public:
 	bool term();
 	bool closeWindow();
 	bool createWindow(int width, int height);
+
 protected:
-	bool process(frame_container& frames);
-	bool processSOS(frame_sp& frame);
+	bool process(frame_container &frames);
+	bool processSOS(frame_sp &frame);
 	bool validateInputPins();
 	bool shouldTriggerSOS();
 	void addInputPin(framemetadata_sp &metadata, string &pinId);
-	bool handleCommand(Command::CommandType type, frame_sp& frame);
+	bool handleCommand(Command::CommandType type, frame_sp &frame);
 	boost::shared_ptr<DetailRenderer> mDetail;
 	ImageViewerModuleProps mProps;
 };

--- a/base/include/ImageViewerModule.h
+++ b/base/include/ImageViewerModule.h
@@ -41,7 +41,7 @@ public:
 
 class ImageViewerModule : public Module {
 public:
-	ImageViewerModule(ImageViewerModuleProps _props=ImageViewerModuleProps(""));
+	ImageViewerModule(ImageViewerModuleProps _props);
 	virtual ~ImageViewerModule();
 	bool init();
 	bool term();

--- a/base/include/ImageViewerModule.h
+++ b/base/include/ImageViewerModule.h
@@ -2,6 +2,10 @@
 
 #include "Module.h"
 
+class DetailRenderer;
+class DetailEgl;
+class DetailImageviewer;
+
 class ImageViewerModuleProps : public ModuleProps
 {
 public:
@@ -9,6 +13,28 @@ public:
 	{
 		strTitle = _strTitle;
 	}
+
+	ImageViewerModuleProps(uint32_t _x_offset,uint32_t _y_offset, uint32_t _width, uint32_t _height) : ModuleProps()
+	{
+        x_offset = _x_offset;
+        y_offset = _y_offset;
+		height = _height;
+		width = _width;
+	}
+	ImageViewerModuleProps(uint32_t _x_offset,uint32_t _y_offset,bool _displayOnTop = true) : ModuleProps()
+	{
+        x_offset = _x_offset;
+        y_offset = _y_offset;
+		height = 0;
+		width = 0;
+		displayOnTop = _displayOnTop ? 1 : 0;
+	}
+
+    uint32_t x_offset;
+    uint32_t y_offset;
+	uint32_t height;
+	uint32_t width;
+	bool displayOnTop;
 
 	string strTitle;
 };
@@ -19,16 +45,15 @@ public:
 	virtual ~ImageViewerModule();
 	bool init();
 	bool term();
+	bool closeWindow();
+	bool createWindow(int width, int height);
 protected:
 	bool process(frame_container& frames);
 	bool processSOS(frame_sp& frame);
 	bool validateInputPins();
 	bool shouldTriggerSOS();
-private:
-	class Detail;
-	boost::shared_ptr<Detail> mDetail;
+	void addInputPin(framemetadata_sp &metadata, string &pinId);
+	bool handleCommand(Command::CommandType type, frame_sp& frame);
+	boost::shared_ptr<DetailRenderer> mDetail;
+	ImageViewerModuleProps mProps;
 };
-
-
-
-

--- a/base/include/ImageViewerModule.h
+++ b/base/include/ImageViewerModule.h
@@ -9,11 +9,7 @@ class DetailImageviewer;
 class ImageViewerModuleProps : public ModuleProps
 {
 public:
-	ImageViewerModuleProps(const string &_strTitle) : ModuleProps()
-	{
-		strTitle = _strTitle;
-	}
-
+#if defined(__arm__) || defined(__aarch64__)
 	ImageViewerModuleProps(uint32_t _x_offset, uint32_t _y_offset, uint32_t _width, uint32_t _height, bool _displayOnTop = true) : ModuleProps()
 	{
 		x_offset = _x_offset;
@@ -30,9 +26,19 @@ public:
 		width = 0;
 		displayOnTop = _displayOnTop ? 1 : 0;
 	}
+	ImageViewerModuleProps(const string &_strTitle) : ModuleProps()
+	{
+		strTitle = _strTitle;
+	}
+#else
+	ImageViewerModuleProps(const string &_strTitle) : ModuleProps()
+	{
+		strTitle = _strTitle;
+	}
+#endif
 
-	uint32_t x_offset;
-	uint32_t y_offset;
+	uint32_t x_offset = 0;
+	uint32_t y_offset = 0;
 	uint32_t height;
 	uint32_t width;
 	bool displayOnTop;

--- a/base/src/ImageViewerModule.cpp
+++ b/base/src/ImageViewerModule.cpp
@@ -18,83 +18,85 @@ class DetailRenderer
 {
 
 public:
-	DetailRenderer(ImageViewerModuleProps& _props) : props(_props) {}
+	DetailRenderer(ImageViewerModuleProps &_props) : props(_props) {}
 
-	~DetailRenderer() 
+	~DetailRenderer()
 	{
-		#if defined(__arm__) || defined(__aarch64__)
-		 if(renderer)
-        {
-            delete renderer;
-        }
-		#endif
+#if defined(__arm__) || defined(__aarch64__)
+		destroyWindow();
+#endif
 	}
 
-	virtual bool compute() = 0;
+	// arm:EGL Renderer , linux/windows:imshow
+
+	virtual bool view() = 0;
 
 	bool eglInitializer(uint32_t _height, uint32_t _width)
 	{
-	#if defined(__arm__) || defined(__aarch64__)
-        uint32_t displayHeight, displayWidth;
-        NvEglRenderer::getDisplayResolution(displayWidth,displayHeight);
-        if(height!=0 && width!=0){
-            x_offset += (displayWidth-width)/2;
-            y_offset += (displayHeight-height)/2;
-            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, width, height, x_offset, y_offset,props.displayOnTop);
-        }else{
-            x_offset += (displayWidth-_width)/2;
-            y_offset += (displayHeight-_height)/2;
-            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, _width, _height, x_offset, y_offset,props.displayOnTop);
-        }
-        if (!renderer)
-        {
-            LOG_ERROR << "Failed to create EGL renderer";
-            return false;
-        }
-	#endif
-        return true;
-    }
+#if defined(__arm__) || defined(__aarch64__)
+		uint32_t displayHeight, displayWidth;
+		NvEglRenderer::getDisplayResolution(displayWidth, displayHeight);
+		if (props.height != 0 && props.width != 0)
+		{
+			props.x_offset += (displayWidth - props.width) / 2;
+			props.y_offset += (displayHeight - props.height) / 2;
+			renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, props.width, props.height, props.x_offset, props.y_offset, props.displayOnTop);
+		}
+		else
+		{
 
-    bool destroyWindow()
-    {
-	#if defined(__arm__) || defined(__aarch64__)
-        if(renderer)
-        {
-            delete renderer;
-        }
-	#else
-	    return true;
-	#endif
-    }
+			props.x_offset += (displayWidth - _width) / 2;
+			props.y_offset += (displayHeight - _height) / 2;
+			renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, _width, _height, props.x_offset, props.y_offset, props.displayOnTop);
+		}
+		if (!renderer)
+		{
+			LOG_ERROR << "Failed to create EGL renderer";
+			return false;
+		}
+#endif
+		return true;
+	}
+
+	bool destroyWindow()
+	{
+#if defined(__arm__) || defined(__aarch64__)
+		if (renderer)
+		{
+			delete renderer;
+		}
+#else
+		return true;
+#endif
+	}
 
 	bool shouldTriggerSOS()
 	{
-		#if defined(__arm__) || defined(__aarch64__)
-		    return !renderer;
-		#else
-		    return !mImg.rows;
-		#endif
+#if defined(__arm__) || defined(__aarch64__)
+		return !renderer;
+#else
+		return !mImg.rows;
+#endif
 	}
 
-	void setMatImg(RawImageMetadata* rawMetadata)
+	void setMatImg(RawImageMetadata *rawMetadata)
 	{
 		mImg = Utils::getMatHeader(rawMetadata);
 	}
 
-	void showImage(frame_sp& frame)
+	void showImage(frame_sp &frame)
 	{
 		mImg.data = (uchar *)frame->data();
-		cv::imshow(mStrTitle, mImg);
+		cv::imshow(props.strTitle, mImg);
 		cv::waitKey(1);
 	}
 
 public:
 	frame_sp inputFrame;
 	ImageViewerModuleProps props;
+
 protected:
 	cv::Mat mImg;
-	std::string mStrTitle;
-	uint32_t x_offset, y_offset, width, height;
 #if defined(__arm__) || defined(__aarch64__)
 	NvEglRenderer *renderer = nullptr;
 #endif
@@ -109,11 +111,11 @@ class DetailEgl : public DetailRenderer
 public:
 	DetailEgl(ImageViewerModuleProps &_props) : DetailRenderer(_props) {}
 
-	bool compute()
+	bool view()
 	{
-		#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
 		renderer->render((static_cast<DMAFDWrapper *>(inputFrame->data()))->getFd());
-		#endif
+#endif
 		return true;
 	}
 };
@@ -123,7 +125,7 @@ class DetailImageviewer : public DetailRenderer
 public:
 	DetailImageviewer(ImageViewerModuleProps &_props) : DetailRenderer(_props) {}
 
-	bool compute()
+	bool view()
 	{
 		showImage(inputFrame);
 		return true;
@@ -140,7 +142,7 @@ bool ImageViewerModule::validateInputPins()
 	framemetadata_sp metadata = getFirstInputMetadata();
 	FrameMetadata::FrameType frameType = metadata->getFrameType();
 	FrameMetadata::MemType inputMemType = metadata->getMemType();
-	
+
 #if defined(__arm__) || defined(__aarch64__)
 	if (inputMemType != FrameMetadata::MemType::DMABUF)
 	{
@@ -165,69 +167,68 @@ bool ImageViewerModule::validateInputPins()
 void ImageViewerModule::addInputPin(framemetadata_sp &metadata, string &pinId)
 {
 	Module::addInputPin(metadata, pinId);
-	FrameMetadata::MemType inputMemType = metadata->getMemType();
 #if defined(__arm__) || defined(__aarch64__)
-    mDetail.reset(new DetailEgl(mProps));
+	mDetail.reset(new DetailEgl(mProps));
 #else
-    mDetail.reset(new DetailImageviewer(mProps));
+	mDetail.reset(new DetailImageviewer(mProps));
 #endif
 }
 
-bool ImageViewerModule::init() 
+bool ImageViewerModule::init()
 {
 	if (!Module::init())
 	{
 		return false;
 	}
-		
-	return true; 
+
+	return true;
 }
 
 bool ImageViewerModule::term() { return Module::term(); }
 
-bool ImageViewerModule::process(frame_container& frames)
+bool ImageViewerModule::process(frame_container &frames)
 {
 	mDetail->inputFrame = frames.cbegin()->second;
 	if (isFrameEmpty(mDetail->inputFrame))
 	{
 		return true;
 	}
-	mDetail->compute();
+	mDetail->view();
 	return true;
 }
 
-bool ImageViewerModule::processSOS(frame_sp& frame)
+bool ImageViewerModule::processSOS(frame_sp &frame)
 {
 	auto inputMetadata = frame->getMetadata();
 	auto frameType = inputMetadata->getFrameType();
 	FrameMetadata::MemType mInputMemType = inputMetadata->getMemType();
-    #if defined(__arm__) || defined(__aarch64__)
-	    int width = 0;
-        int height =0;
-		switch (frameType)
-        {
-        case FrameMetadata::FrameType::RAW_IMAGE:
-        {
-           auto metadata = FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata);
-           width = metadata->getWidth();
-           height = metadata->getHeight();
-        }
-        break;
-        case FrameMetadata::FrameType::RAW_IMAGE_PLANAR:
-        {
-           auto metadata = FrameMetadataFactory::downcast<RawImagePlanarMetadata>(inputMetadata);
-           width = metadata->getWidth(0);
-           height = metadata->getHeight(0);
-        }
-        break;
-        default:
-        throw AIPException(AIP_FATAL, "Unsupported FrameType<" + std::to_string(frameType) + ">");
-        }
+#if defined(__arm__) || defined(__aarch64__)
+	int width = 0;
+	int height = 0;
+	switch (frameType)
+	{
+	case FrameMetadata::FrameType::RAW_IMAGE:
+	{
+		auto metadata = FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata);
+		width = metadata->getWidth();
+		height = metadata->getHeight();
+	}
+	break;
+	case FrameMetadata::FrameType::RAW_IMAGE_PLANAR:
+	{
+		auto metadata = FrameMetadataFactory::downcast<RawImagePlanarMetadata>(inputMetadata);
+		width = metadata->getWidth(0);
+		height = metadata->getHeight(0);
+	}
+	break;
+	default:
+		throw AIPException(AIP_FATAL, "Unsupported FrameType<" + std::to_string(frameType) + ">");
+	}
 
-		mDetail->eglInitializer(height,width);
-	#else
-		mDetail->setMatImg(FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata));
-	#endif
+	mDetail->eglInitializer(height, width);
+#else
+	mDetail->setMatImg(FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata));
+#endif
 	return true;
 }
 
@@ -239,44 +240,42 @@ bool ImageViewerModule::shouldTriggerSOS()
 bool ImageViewerModule::handleCommand(Command::CommandType type, frame_sp &frame)
 {
 #if defined(__arm__) || defined(__aarch64__)
-    if (type == Command::CommandType::DeleteWindow)
-    {
-        EglRendererCloseWindow cmd;
-        getCommand(cmd, frame);
-        mDetail->destroyWindow();
-        return true;
-    }
-    else if (type == Command::CommandType::CreateWindow)
-    {
-        EglRendererCreateWindow cmd;
-        getCommand(cmd, frame);
-        mDetail->eglInitializer(cmd.width, cmd.height);
-        return true;
-    }
-    return Module::handleCommand(type, frame);
+	if (type == Command::CommandType::DeleteWindow)
+	{
+		mDetail->destroyWindow();
+		return true;
+	}
+	else if (type == Command::CommandType::CreateWindow)
+	{
+		EglRendererCreateWindow cmd;
+		getCommand(cmd, frame);
+		mDetail->eglInitializer(cmd.width, cmd.height);
+		return true;
+	}
+	return Module::handleCommand(type, frame);
 #else
-   return true;
+	return true;
 #endif
 }
 
 bool ImageViewerModule::closeWindow()
 {
 #if defined(__arm__) || defined(__aarch64__)
-    EglRendererCloseWindow cmd;
-    return queueCommand(cmd);
+	EglRendererCloseWindow cmd;
+	return queueCommand(cmd);
 #else
-   return true;
+	return true;
 #endif
 }
 
 bool ImageViewerModule::createWindow(int width, int height)
 {
 #if defined(__arm__) || defined(__aarch64__)
-    EglRendererCreateWindow cmd;
-    cmd.width = width;
-    cmd.height = height;
-    return queueCommand(cmd);
+	EglRendererCreateWindow cmd;
+	cmd.width = width;
+	cmd.height = height;
+	return queueCommand(cmd);
 #else
-   return true;
+	return true;
 #endif
 }

--- a/base/src/ImageViewerModule.cpp
+++ b/base/src/ImageViewerModule.cpp
@@ -32,7 +32,7 @@ public:
 
 	virtual bool compute() = 0;
 
-	bool eglInitializer(uint32_t _height, uint32_t _width , bool _displayOnTop)
+	bool eglInitializer(uint32_t _height, uint32_t _width)
 	{
 	#if defined(__arm__) || defined(__aarch64__)
         uint32_t displayHeight, displayWidth;
@@ -40,11 +40,11 @@ public:
         if(height!=0 && width!=0){
             x_offset += (displayWidth-width)/2;
             y_offset += (displayHeight-height)/2;
-            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, width, height, x_offset, y_offset,displayOnTop);
+            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, width, height, x_offset, y_offset,props.displayOnTop);
         }else{
             x_offset += (displayWidth-_width)/2;
             y_offset += (displayHeight-_height)/2;
-            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, _width, _height, x_offset, y_offset, displayOnTop);
+            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, _width, _height, x_offset, y_offset,props.displayOnTop);
         }
         if (!renderer)
         {
@@ -85,18 +85,16 @@ public:
 	{
 		mImg.data = (uchar *)frame->data();
 		cv::imshow(mStrTitle, mImg);
-		cv::waitKey(1); //use 33 for linux Grrr
+		cv::waitKey(1);
 	}
 
 public:
-	cv::Mat mImg;	
-	std::string mStrTitle;
-    uint32_t x_offset,y_offset,width,height;
-    bool displayOnTop;
 	frame_sp inputFrame;
-	frame_sp outputFrame;
 	ImageViewerModuleProps props;
-
+protected:
+	cv::Mat mImg;
+	std::string mStrTitle;
+	uint32_t x_offset, y_offset, width, height;
 #if defined(__arm__) || defined(__aarch64__)
 	NvEglRenderer *renderer = nullptr;
 #endif
@@ -226,7 +224,7 @@ bool ImageViewerModule::processSOS(frame_sp& frame)
         throw AIPException(AIP_FATAL, "Unsupported FrameType<" + std::to_string(frameType) + ">");
         }
 
-		mDetail->eglInitializer(height,width,mDetail->displayOnTop);
+		mDetail->eglInitializer(height,width);
 	#else
 		mDetail->setMatImg(FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata));
 	#endif
@@ -252,7 +250,7 @@ bool ImageViewerModule::handleCommand(Command::CommandType type, frame_sp &frame
     {
         EglRendererCreateWindow cmd;
         getCommand(cmd, frame);
-        mDetail->eglInitializer(cmd.width, cmd.height,mDetail->displayOnTop);
+        mDetail->eglInitializer(cmd.width, cmd.height);
         return true;
     }
     return Module::handleCommand(type, frame);

--- a/base/src/ImageViewerModule.cpp
+++ b/base/src/ImageViewerModule.cpp
@@ -8,13 +8,73 @@
 #include "Logger.h"
 #include "Utils.h"
 
-class ImageViewerModule::Detail
+#if defined(__arm__) || defined(__aarch64__)
+#include "ApraNvEglRenderer.h"
+#include "DMAFDWrapper.h"
+#include "Command.h"
+#endif
+
+class DetailRenderer
 {
 
 public:
-	Detail(std::string& strTitle): mStrTitle(strTitle) {}
+	DetailRenderer(ImageViewerModuleProps& _props) : props(_props) {}
 
-	~Detail() {}
+	~DetailRenderer() 
+	{
+		#if defined(__arm__) || defined(__aarch64__)
+		 if(renderer)
+        {
+            delete renderer;
+        }
+		#endif
+	}
+
+	virtual bool compute() = 0;
+
+	bool eglInitializer(uint32_t _height, uint32_t _width , bool _displayOnTop)
+	{
+	#if defined(__arm__) || defined(__aarch64__)
+        uint32_t displayHeight, displayWidth;
+        NvEglRenderer::getDisplayResolution(displayWidth,displayHeight);
+        if(height!=0 && width!=0){
+            x_offset += (displayWidth-width)/2;
+            y_offset += (displayHeight-height)/2;
+            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, width, height, x_offset, y_offset,displayOnTop);
+        }else{
+            x_offset += (displayWidth-_width)/2;
+            y_offset += (displayHeight-_height)/2;
+            renderer = NvEglRenderer::createEglRenderer(__TIMESTAMP__, _width, _height, x_offset, y_offset, displayOnTop);
+        }
+        if (!renderer)
+        {
+            LOG_ERROR << "Failed to create EGL renderer";
+            return false;
+        }
+	#endif
+        return true;
+    }
+
+    bool destroyWindow()
+    {
+	#if defined(__arm__) || defined(__aarch64__)
+        if(renderer)
+        {
+            delete renderer;
+        }
+	#else
+	    return true;
+	#endif
+    }
+
+	bool shouldTriggerSOS()
+	{
+		#if defined(__arm__) || defined(__aarch64__)
+		    return !renderer;
+		#else
+		    return !mImg.rows;
+		#endif
+	}
 
 	void setMatImg(RawImageMetadata* rawMetadata)
 	{
@@ -28,21 +88,49 @@ public:
 		cv::waitKey(1); //use 33 for linux Grrr
 	}
 
-	bool shouldTriggerSOS()
-	{
-		return !mImg.rows;
-	}
-		
-private:
+public:
 	cv::Mat mImg;	
 	std::string mStrTitle;
+    uint32_t x_offset,y_offset,width,height;
+    bool displayOnTop;
+	frame_sp inputFrame;
+	frame_sp outputFrame;
+	ImageViewerModuleProps props;
+
+#if defined(__arm__) || defined(__aarch64__)
+	NvEglRenderer *renderer = nullptr;
+#endif
 };
 
-ImageViewerModule::ImageViewerModule(ImageViewerModuleProps _props) : Module(SINK, "ImageViewerModule", _props) {
-	mDetail.reset(new Detail(_props.strTitle));
-}
+ImageViewerModule::ImageViewerModule(ImageViewerModuleProps _props) : Module(SINK, "ImageViewerModule", _props), mProps(_props) {}
 
 ImageViewerModule::~ImageViewerModule() {}
+
+class DetailEgl : public DetailRenderer
+{
+public:
+	DetailEgl(ImageViewerModuleProps &_props) : DetailRenderer(_props) {}
+
+	bool compute()
+	{
+		#if defined(__arm__) || defined(__aarch64__)
+		renderer->render((static_cast<DMAFDWrapper *>(inputFrame->data()))->getFd());
+		#endif
+		return true;
+	}
+};
+
+class DetailImageviewer : public DetailRenderer
+{
+public:
+	DetailImageviewer(ImageViewerModuleProps &_props) : DetailRenderer(_props) {}
+
+	bool compute()
+	{
+		showImage(inputFrame);
+		return true;
+	}
+};
 
 bool ImageViewerModule::validateInputPins()
 {
@@ -51,16 +139,40 @@ bool ImageViewerModule::validateInputPins()
 		LOG_ERROR << "<" << getId() << ">::validateInputPins size is expected to be 1. Actual<" << getNumberOfInputPins() << ">";
 		return false;
 	}
-
 	framemetadata_sp metadata = getFirstInputMetadata();
 	FrameMetadata::FrameType frameType = metadata->getFrameType();
+	FrameMetadata::MemType inputMemType = metadata->getMemType();
+	
+#if defined(__arm__) || defined(__aarch64__)
+	if (inputMemType != FrameMetadata::MemType::DMABUF)
+	{
+		LOG_ERROR << "<" << getId() << ">::validateInputPins input memType is expected to be DMABUF. Actual<" << inputMemType << ">";
+		return false;
+	}
+	if (frameType != FrameMetadata::RAW_IMAGE && frameType != FrameMetadata::RAW_IMAGE_PLANAR)
+	{
+		LOG_ERROR << "<" << getId() << ">::validateInputPins input frameType is expected to be RAW_IMAGE or RAW_IMAGE_PLANAR. Actual<" << frameType << ">";
+		return false;
+	}
+#else
 	if (frameType != FrameMetadata::RAW_IMAGE)
 	{
 		LOG_ERROR << "<" << getId() << ">::validateInputPins input frameType is expected to be RAW_IMAGE. Actual<" << frameType << ">";
 		return false;
 	}
-
+#endif
 	return true;
+}
+
+void ImageViewerModule::addInputPin(framemetadata_sp &metadata, string &pinId)
+{
+	Module::addInputPin(metadata, pinId);
+	FrameMetadata::MemType inputMemType = metadata->getMemType();
+#if defined(__arm__) || defined(__aarch64__)
+    mDetail.reset(new DetailEgl(mProps));
+#else
+    mDetail.reset(new DetailImageviewer(mProps));
+#endif
 }
 
 bool ImageViewerModule::init() 
@@ -77,24 +189,96 @@ bool ImageViewerModule::term() { return Module::term(); }
 
 bool ImageViewerModule::process(frame_container& frames)
 {
-	auto frame = getFrameByType(frames, FrameMetadata::RAW_IMAGE);
-	if (isFrameEmpty(frame))
+	mDetail->inputFrame = frames.cbegin()->second;
+	if (isFrameEmpty(mDetail->inputFrame))
 	{
 		return true;
 	}
-	
-	mDetail->showImage(frame);
+	mDetail->compute();
 	return true;
 }
 
 bool ImageViewerModule::processSOS(frame_sp& frame)
 {
-	auto metadata = frame->getMetadata();
-	mDetail->setMatImg(FrameMetadataFactory::downcast<RawImageMetadata>(metadata));
+	auto inputMetadata = frame->getMetadata();
+	auto frameType = inputMetadata->getFrameType();
+	FrameMetadata::MemType mInputMemType = inputMetadata->getMemType();
+    #if defined(__arm__) || defined(__aarch64__)
+	    int width = 0;
+        int height =0;
+		switch (frameType)
+        {
+        case FrameMetadata::FrameType::RAW_IMAGE:
+        {
+           auto metadata = FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata);
+           width = metadata->getWidth();
+           height = metadata->getHeight();
+        }
+        break;
+        case FrameMetadata::FrameType::RAW_IMAGE_PLANAR:
+        {
+           auto metadata = FrameMetadataFactory::downcast<RawImagePlanarMetadata>(inputMetadata);
+           width = metadata->getWidth(0);
+           height = metadata->getHeight(0);
+        }
+        break;
+        default:
+        throw AIPException(AIP_FATAL, "Unsupported FrameType<" + std::to_string(frameType) + ">");
+        }
+
+		mDetail->eglInitializer(height,width,mDetail->displayOnTop);
+	#else
+		mDetail->setMatImg(FrameMetadataFactory::downcast<RawImageMetadata>(inputMetadata));
+	#endif
 	return true;
 }
 
 bool ImageViewerModule::shouldTriggerSOS()
 {
 	return mDetail->shouldTriggerSOS();
+}
+
+bool ImageViewerModule::handleCommand(Command::CommandType type, frame_sp &frame)
+{
+#if defined(__arm__) || defined(__aarch64__)
+    if (type == Command::CommandType::DeleteWindow)
+    {
+        EglRendererCloseWindow cmd;
+        getCommand(cmd, frame);
+        mDetail->destroyWindow();
+        return true;
+    }
+    else if (type == Command::CommandType::CreateWindow)
+    {
+        EglRendererCreateWindow cmd;
+        getCommand(cmd, frame);
+        mDetail->eglInitializer(cmd.width, cmd.height,mDetail->displayOnTop);
+        return true;
+    }
+    return Module::handleCommand(type, frame);
+#else
+   return true;
+#endif
+}
+
+bool ImageViewerModule::closeWindow()
+{
+#if defined(__arm__) || defined(__aarch64__)
+    EglRendererCloseWindow cmd;
+    return queueCommand(cmd);
+#else
+   return true;
+#endif
+}
+
+bool ImageViewerModule::createWindow(int width, int height)
+{
+#if defined(__arm__) || defined(__aarch64__)
+    EglRendererCreateWindow cmd;
+    cmd.width = width;
+    cmd.height = height;
+    return queueCommand(cmd);
+#else
+   return true;
+#endif
 }

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -49,10 +49,10 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
 	NvV4L2CameraProps nvCamProps(640, 360, 10);
 	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
 
-	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::NV12));
+	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::RGBA));
 	source->setNext(transform);
 
-    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,1)));
 	transform->setNext(sink);
 
     PipeLine p("test");
@@ -63,13 +63,48 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
 
 	p.run_all_threaded();
 
-	boost::this_thread::sleep_for(boost::chrono::seconds(20));
+	boost::this_thread::sleep_for(boost::chrono::seconds(40));
 	Logger::setLogLevel(boost::log::trivial::severity_level::error);
 
 	p.stop();
 	p.term();
 	p.wait_for_all();
 	#endif 
+}
+
+BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
+{
+	NvV4L2CameraProps nvCamProps(640,360, 10);
+    auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
+
+    NvTransformProps nvprops(ImageMetadata::RGBA);
+    auto transform = boost::shared_ptr<Module>(new NvTransform(nvprops));
+    source->setNext(transform);
+
+	auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+	transform->setNext(sink);
+
+	PipeLine p("test");
+	p.appendModule(source);
+	BOOST_TEST(p.init());
+
+	Logger::setLogLevel(boost::log::trivial::severity_level::info);
+
+	p.run_all_threaded();
+
+	boost::this_thread::sleep_for(boost::chrono::seconds(5));
+	sink->closeWindow();
+
+	boost::this_thread::sleep_for(boost::chrono::seconds(10));
+	sink->createWindow(200,200);
+
+	boost::this_thread::sleep_for(boost::chrono::seconds(120));
+	Logger::setLogLevel(boost::log::trivial::severity_level::error);
+
+	p.stop();
+	p.term();
+
+	p.wait_for_all(); 
 }
 
 BOOST_AUTO_TEST_CASE(viewer_test,*boost::unit_test::disabled())

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -74,6 +74,7 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
 
 BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 {
+	#if defined(__arm__) || defined(__aarch64__)
 	NvV4L2CameraProps nvCamProps(640,360, 10);
     auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
 
@@ -104,7 +105,8 @@ BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 	p.stop();
 	p.term();
 
-	p.wait_for_all(); 
+	p.wait_for_all();
+	#endif 
 }
 
 BOOST_AUTO_TEST_CASE(viewer_test,*boost::unit_test::disabled())

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -1,0 +1,98 @@
+#include <boost/test/unit_test.hpp>
+#include "FileReaderModule.h"
+#include "Logger.h"
+#include "PipeLine.h"
+#include "RawImageMetadata.h"
+#include "RawImagePlanarMetadata.h"
+#include "ImageViewerModule.h"
+#include "WebCamSource.h"
+
+#if defined(__arm__) || defined(__aarch64__)
+#include "NvV4L2Camera.h"
+#include "NvTransform.h"
+#endif
+
+BOOST_AUTO_TEST_SUITE(imageviewermodule_tests)
+
+BOOST_AUTO_TEST_CASE(Dma_Renderer_Planarimage,*boost::unit_test::disabled())
+{
+	#if defined(__arm__) || defined(__aarch64__)
+	NvV4L2CameraProps nvCamProps(640, 360, 10);
+	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
+
+	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::NV12));
+	source->setNext(transform);
+
+    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+	transform->setNext(sink);
+
+    PipeLine p("test");
+	p.appendModule(source);
+	BOOST_TEST(p.init());
+
+	Logger::setLogLevel(boost::log::trivial::severity_level::info);
+
+	p.run_all_threaded();
+
+	boost::this_thread::sleep_for(boost::chrono::seconds(20));
+	Logger::setLogLevel(boost::log::trivial::severity_level::error);
+
+	p.stop();
+	p.term();
+	p.wait_for_all();
+	#endif 
+}
+
+BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
+{
+	#if defined(__arm__) || defined(__aarch64__)
+	NvV4L2CameraProps nvCamProps(640, 360, 10);
+	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
+
+	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::NV12));
+	source->setNext(transform);
+
+    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+	transform->setNext(sink);
+
+    PipeLine p("test");
+	p.appendModule(source);
+	BOOST_TEST(p.init());
+
+	Logger::setLogLevel(boost::log::trivial::severity_level::info);
+
+	p.run_all_threaded();
+
+	boost::this_thread::sleep_for(boost::chrono::seconds(20));
+	Logger::setLogLevel(boost::log::trivial::severity_level::error);
+
+	p.stop();
+	p.term();
+	p.wait_for_all();
+	#endif 
+}
+
+BOOST_AUTO_TEST_CASE(viewer_test,*boost::unit_test::disabled())
+{   
+	WebCamSourceProps webCamSourceprops(-1, 640, 480);
+	auto source = boost::shared_ptr<WebCamSource>(new WebCamSource(webCamSourceprops));
+
+	auto sink = boost::shared_ptr<Module>(new ImageViewerModule(ImageViewerModuleProps("imageview")));
+	source->setNext(sink);
+
+	PipeLine p("test");
+	p.appendModule(source);
+	p.init();
+
+	p.run_all_threaded();
+	boost::this_thread::sleep_for(boost::chrono::seconds(10));
+
+	LOG_INFO << "profiling done - stopping the pipeline";
+	p.stop();
+	p.term();
+	p.wait_for_all();
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -14,19 +14,19 @@
 
 BOOST_AUTO_TEST_SUITE(imageviewermodule_tests)
 
-BOOST_AUTO_TEST_CASE(Dma_Renderer_Planarimage,*boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(Dma_Renderer_Planarimage, *boost::unit_test::disabled())
 {
-	#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
 	NvV4L2CameraProps nvCamProps(640, 360, 10);
 	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
 
 	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::NV12));
 	source->setNext(transform);
 
-    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+	auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0, 0, 0)));
 	transform->setNext(sink);
 
-    PipeLine p("test");
+	PipeLine p("test");
 	p.appendModule(source);
 	BOOST_TEST(p.init());
 
@@ -40,22 +40,22 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Planarimage,*boost::unit_test::disabled())
 	p.stop();
 	p.term();
 	p.wait_for_all();
-	#endif 
+#endif
 }
 
-BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
+BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage, *boost::unit_test::disabled())
 {
-	#if defined(__arm__) || defined(__aarch64__)
+#if defined(__arm__) || defined(__aarch64__)
 	NvV4L2CameraProps nvCamProps(640, 360, 10);
 	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
 
 	auto transform = boost::shared_ptr<Module>(new NvTransform(ImageMetadata::RGBA));
 	source->setNext(transform);
 
-    auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,1)));
+	auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0, 0, 1)));
 	transform->setNext(sink);
 
-    PipeLine p("test");
+	PipeLine p("test");
 	p.appendModule(source);
 	BOOST_TEST(p.init());
 
@@ -69,20 +69,20 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Rawimage,*boost::unit_test::disabled())
 	p.stop();
 	p.term();
 	p.wait_for_all();
-	#endif 
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 {
-	#if defined(__arm__) || defined(__aarch64__)
-	NvV4L2CameraProps nvCamProps(640,360, 10);
-    auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
+#if defined(__arm__) || defined(__aarch64__)
+	NvV4L2CameraProps nvCamProps(640, 360, 10);
+	auto source = boost::shared_ptr<Module>(new NvV4L2Camera(nvCamProps));
 
-    NvTransformProps nvprops(ImageMetadata::RGBA);
-    auto transform = boost::shared_ptr<Module>(new NvTransform(nvprops));
-    source->setNext(transform);
+	NvTransformProps nvprops(ImageMetadata::RGBA);
+	auto transform = boost::shared_ptr<Module>(new NvTransform(nvprops));
+	source->setNext(transform);
 
-	auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0,0,0)));
+	auto sink = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(ImageViewerModuleProps(0, 0, 0)));
 	transform->setNext(sink);
 
 	PipeLine p("test");
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 	sink->closeWindow();
 
 	boost::this_thread::sleep_for(boost::chrono::seconds(10));
-	sink->createWindow(200,200);
+	sink->createWindow(200, 200);
 
 	boost::this_thread::sleep_for(boost::chrono::seconds(120));
 	Logger::setLogLevel(boost::log::trivial::severity_level::error);
@@ -106,11 +106,11 @@ BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 	p.term();
 
 	p.wait_for_all();
-	#endif 
+#endif
 }
 
-BOOST_AUTO_TEST_CASE(viewer_test,*boost::unit_test::disabled())
-{   
+BOOST_AUTO_TEST_CASE(viewer_test, *boost::unit_test::disabled())
+{
 	WebCamSourceProps webCamSourceprops(-1, 640, 480);
 	auto source = boost::shared_ptr<WebCamSource>(new WebCamSource(webCamSourceprops));
 
@@ -128,8 +128,6 @@ BOOST_AUTO_TEST_CASE(viewer_test,*boost::unit_test::disabled())
 	p.stop();
 	p.term();
 	p.wait_for_all();
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -110,7 +110,6 @@ BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 
 BOOST_AUTO_TEST_CASE(viewer_test, *boost::unit_test::disabled())
 {
-	#if defined(!__arm__) || defined(!__aarch64__)
 	WebCamSourceProps webCamSourceprops(-1, 640, 480);
 	auto source = boost::shared_ptr<WebCamSource>(new WebCamSource(webCamSourceprops));
 
@@ -128,7 +127,6 @@ BOOST_AUTO_TEST_CASE(viewer_test, *boost::unit_test::disabled())
 	p.stop();
 	p.term();
 	p.wait_for_all();
-	#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/imageviewermodule_tests.cpp
+++ b/base/test/imageviewermodule_tests.cpp
@@ -1,5 +1,4 @@
 #include <boost/test/unit_test.hpp>
-#include "FileReaderModule.h"
 #include "Logger.h"
 #include "PipeLine.h"
 #include "RawImageMetadata.h"
@@ -34,7 +33,7 @@ BOOST_AUTO_TEST_CASE(Dma_Renderer_Planarimage, *boost::unit_test::disabled())
 
 	p.run_all_threaded();
 
-	boost::this_thread::sleep_for(boost::chrono::seconds(20));
+	boost::this_thread::sleep_for(boost::chrono::seconds(5));
 	Logger::setLogLevel(boost::log::trivial::severity_level::error);
 
 	p.stop();
@@ -111,6 +110,7 @@ BOOST_AUTO_TEST_CASE(open_close_window, *boost::unit_test::disabled())
 
 BOOST_AUTO_TEST_CASE(viewer_test, *boost::unit_test::disabled())
 {
+	#if defined(!__arm__) || defined(!__aarch64__)
 	WebCamSourceProps webCamSourceprops(-1, 640, 480);
 	auto source = boost::shared_ptr<WebCamSource>(new WebCamSource(webCamSourceprops));
 
@@ -128,6 +128,7 @@ BOOST_AUTO_TEST_CASE(viewer_test, *boost::unit_test::disabled())
 	p.stop();
 	p.term();
 	p.wait_for_all();
+	#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #282 

**Description**

Merged Eglrenderer module into imageviewer module now we have one renderer module , if device is arm and memtype is dma it uses egl for rendering else it uses imageviewer(opencv->imshow)

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

NO

Type Choose one: Enhancement

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
