### PR TITLE
Mp4 Writer video playback compatibility fix for high resolution videos

### DIFF
--- a/base/test/mp4writersink_tests.cpp
+++ b/base/test/mp4writersink_tests.cpp
@@ -38,7 +38,7 @@ void writeH264(bool readLoop, int sleepSeconds, std::string outFolderPath, int c
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(width, height));
 	fileReader->addOutputPin(h264ImageMetadata);
 
-	auto mp4WriterSinkProps = Mp4WriterSinkProps(chunkTime, 10, 100, outFolderPath);
+	auto mp4WriterSinkProps = Mp4WriterSinkProps(chunkTime, 10, 24, outFolderPath);
 	mp4WriterSinkProps.logHealth = true;
 	mp4WriterSinkProps.logHealthFrequency = 100;
 	auto mp4WriterSink = boost::shared_ptr<Module>(new Mp4WriterSink(mp4WriterSinkProps));


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**
Fixes the bug in Mp4Writer, where the frame size was getting appended only to last two bytes of nalu separator , instead it should it all the four bytes of nalu separator to save the frame size. Because frame size cross 2^16 - 1 which is more than 2 bytes.

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
