### PR TITLE
Mp4Reader getSetProps enhancement

### DIFF
--- a/base/include/Mp4ReaderSource.h
+++ b/base/include/Mp4ReaderSource.h
@@ -40,7 +40,7 @@ public:
 		auto canonicalVideoPath = boost::filesystem::canonical(_videoPath);
 		videoPath = canonicalVideoPath.string();
 		parseFS = _parseFS;
-		skipDir = boost::filesystem::path(canonicalVideoPath).parent_path().parent_path().parent_path().string();
+		skipDir = boost::filesystem::path(canonicalVideoPath).string();
 		bFramesEnabled = _bFramesEnabled;
 		direction = _direction;
 		giveLiveTS = _giveLiveTS;
@@ -51,11 +51,10 @@ public:
 		parseFSTimeoutDuration = _parseFSTimeoutDuration;
 		readLoop = _readLoop;
 		reInitInterval = _reInitInterval;
-		if (parseFS)
+		if (parseFS && boost::filesystem::path(videoPath).extension() == ".mp4")
 		{
 			skipDir = boost::filesystem::path(videoPath).parent_path().parent_path().parent_path().string();
 		}
-
 	}
 
 	void setMaxFrameSizes(size_t _maxImgFrameSize, size_t _maxMetadataFrameSize)

--- a/base/include/Mp4ReaderSource.h
+++ b/base/include/Mp4ReaderSource.h
@@ -40,7 +40,6 @@ public:
 		auto canonicalVideoPath = boost::filesystem::canonical(_videoPath);
 		videoPath = canonicalVideoPath.string();
 		parseFS = _parseFS;
-		skipDir = boost::filesystem::path(canonicalVideoPath).string();
 		bFramesEnabled = _bFramesEnabled;
 		direction = _direction;
 		giveLiveTS = _giveLiveTS;
@@ -51,9 +50,15 @@ public:
 		parseFSTimeoutDuration = _parseFSTimeoutDuration;
 		readLoop = _readLoop;
 		reInitInterval = _reInitInterval;
+
+		//If the input file path is the full video path then its root dir will be skipDir else if the input path is only root dir path then it is directly assigned to skipDir.
 		if (parseFS && boost::filesystem::path(videoPath).extension() == ".mp4")
 		{
 			skipDir = boost::filesystem::path(videoPath).parent_path().parent_path().parent_path().string();
+		}
+		else
+		{
+			skipDir = boost::filesystem::path(canonicalVideoPath).string();
 		}
 	}
 

--- a/base/src/Mp4ReaderSource.cpp
+++ b/base/src/Mp4ReaderSource.cpp
@@ -46,7 +46,17 @@ public:
 	bool Init()
 	{
 		sentEOSSignal = false;
-
+		auto filePath = boost::filesystem::path(mState.mVideoPath);
+		if (filePath.extension() != ".mp4")
+		{
+			if (!cof->probe(filePath, mState.mVideoPath))
+			{
+				LOG_DEBUG << "Mp4 file is not present" << ">";
+				isVideoFileFound = false;
+				return true;
+			}
+			isVideoFileFound = true;
+		}
 		if (mProps.parseFS)
 		{
 			auto boostVideoTS = boost::filesystem::path(mState.mVideoPath).stem().string();
@@ -104,7 +114,15 @@ public:
 			return;
 		}
 
-		auto tempSkipDir = boost::filesystem::path(tempVideoPath).parent_path().parent_path().parent_path().string();
+		std::string tempSkipDir;
+		if (boost::filesystem::path(tempVideoPath).extension() == ".mp4")
+		{
+			tempSkipDir = boost::filesystem::path(tempVideoPath).parent_path().parent_path().parent_path().string();
+		}
+		else
+		{
+			tempSkipDir = boost::filesystem::path(tempVideoPath).string();
+		}
 		if (props.parseFS && mProps.skipDir == tempSkipDir && mState.mVideoPath != "")
 		{
 			if (mProps.videoPath == props.videoPath)
@@ -116,6 +134,18 @@ public:
 		if (props.parseFS && mProps.skipDir != tempSkipDir && mState.mVideoPath != "")
 		{
 			sentEOSSignal = false;
+
+			if (boost::filesystem::path(tempVideoPath).extension() != ".mp4")
+			{
+				if (!cof->probe(tempVideoPath, mState.mVideoPath))
+				{
+					LOG_DEBUG << "Mp4 file is not present" << ">";
+					isVideoFileFound = false;
+					return;
+				}
+				isVideoFileFound = true;
+				tempVideoPath = mState.mVideoPath;
+			}
 
 			auto boostVideoTS = boost::filesystem::path(tempVideoPath).stem().string();
 			uint64_t start_parsing_ts = 0;

--- a/base/test/mp4readersource_tests.cpp
+++ b/base/test/mp4readersource_tests.cpp
@@ -202,7 +202,6 @@ BOOST_AUTO_TEST_CASE(read_timeStamp_from_custom_fileName)
 {
 	/* file structure parsing test */
 	std::string videoPath = "./data/Mp4_videos/h264_video/apraH264.mp4";
-	std::string outPath = "data/testOutput/outFrames";
 	auto frameType = FrameMetadata::FrameType::H264_DATA;
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
 	bool parseFS = false;
@@ -217,7 +216,6 @@ BOOST_AUTO_TEST_CASE(read_timeStamp_from_custom_fileName)
 BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder)
 {
 	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
-	std::string outPath = "./data/testOutput/outFrames/";
 	bool parseFS = true;
 	auto frameType = FrameMetadata::FrameType::H264_DATA;
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
@@ -248,10 +246,9 @@ BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder)
 	BOOST_TEST(frame->timestamp == 1673420640350);
 }
 
-BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder_with_custom_file_name)
+BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder_to_custom_file_name)
 {
 	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
-	std::string outPath = "./data/testOutput/outFrames/";
 	bool parseFS = true;
 	auto frameType = FrameMetadata::FrameType::H264_DATA;
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
@@ -283,10 +280,9 @@ BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder_with_custom_file_name)
 	BOOST_TEST(frame->timestamp == 1673420640350);
 }
 
-BOOST_AUTO_TEST_CASE(NotParseFs_to_parseFS)
+BOOST_AUTO_TEST_CASE(getSetProps_NotParseFs_to_parseFS)
 {
 	std::string videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/apraH264.mp4";
-	std::string outPath = "./data/testOutput/outFrames/";
 	bool parseFS = false;
 	auto frameType = FrameMetadata::FrameType::H264_DATA;
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
@@ -318,10 +314,129 @@ BOOST_AUTO_TEST_CASE(NotParseFs_to_parseFS)
 	BOOST_TEST(frame->timestamp == 1685604318680);
 }
 
-BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder_fail)
+BOOST_AUTO_TEST_CASE(getSetProps_custom_file_name_to_root_dir)
+{
+	std::string videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/apraH264.mp4";
+	bool parseFS = false;
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+	frame_container frames;
+
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	auto frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+
+	for (int i = 0; i < 50; i++)
+	{
+		s.mp4Reader->step();
+		frames = s.sink->pop();
+	}
+
+	//change the video file path , Now read first frame new video of changed root dir instead of last frame of open video 
+	auto propsChange = s.mp4Reader->getProps();
+	// To read custom file name parseFS needs to be disabled
+	propsChange.parseFS = true;
+	propsChange.videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/";
+	s.mp4Reader->setProps(propsChange);
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+}
+
+BOOST_AUTO_TEST_CASE(getSetProps_root_dir_to_custom_file_name)
+{
+	std::string videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/";
+	bool parseFS = true;
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+	frame_container frames;
+
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	auto frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+
+	for (int i = 0; i < 50; i++)
+	{
+		s.mp4Reader->step();
+		frames = s.sink->pop();
+	}
+
+	//change the video file path , Now read first frame new video of changed root dir instead of last frame of open video 
+	auto propsChange = s.mp4Reader->getProps();
+	// To read custom file name parseFS needs to be disabled
+	propsChange.parseFS = false;
+	propsChange.videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/apraH264.mp4";
+	s.mp4Reader->setProps(propsChange);
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+}
+
+BOOST_AUTO_TEST_CASE(getSetProps_filename_to_root_dir)
 {
 	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
-	std::string outPath = "./data/testOutput/outFrames/";
+	bool parseFS = true;
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+	frame_container frames;
+
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	auto frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1686723796848);
+
+	//change the video file path , Now read first frame new video of changed root dir instead of last frame of open video 
+	auto propsChange = s.mp4Reader->getProps();
+	// To read custom file name parseFS needs to be disabled
+	propsChange.parseFS = true;
+	propsChange.videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/";
+	s.mp4Reader->setProps(propsChange);
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+}
+
+BOOST_AUTO_TEST_CASE(getSetProps_root_dir_to_filename)
+{
+	std::string videoPath = "./data/Mp4_videos/mp4_seeks_tests_h264/";
+	bool parseFS = true;
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+	frame_container frames;
+
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	auto frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1673420640350);
+
+	//change the video file path , Now read first frame new video of changed root dir instead of last frame of open video 
+	auto propsChange = s.mp4Reader->getProps();
+	// To read custom file name parseFS needs to be disabled
+	propsChange.parseFS = true;
+	propsChange.videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	s.mp4Reader->setProps(propsChange);
+	s.mp4Reader->step();
+	frames = s.sink->pop();
+	frame = frames.begin()->second;
+	BOOST_TEST(frame->timestamp == 1686723796848);
+}
+
+BOOST_AUTO_TEST_CASE(getSetProps_change_root_folder_fail)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";	
 	bool parseFS = true;
 	auto frameType = FrameMetadata::FrameType::H264_DATA;
 	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #273 

**Description**
Did Mp4Reader changes related to following cases and added test for them:

Changing file path from custom file name to only root dir and vice versa.
Changing filename to only root dir and vice versa.

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
