### PR TITLE
Fixed Mp4Writer frame buffer modify issue

### DIFF
--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "e839c8f19e3aa844ed0a6212e05349c90b85dde0",
+  "builtin-baseline": "356814e3b10f457f01d9dfdc45e1b2cac0ff6b60",
   "dependencies": [
     {
       "name": "opencv4",


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #302 

**Description**
Fixed the frame_sp buffer modify issue. Earlier the input frame_sp->data() (Nalu seperators) used to get updated to support the video playback capability across all the players. To avoid modifying the frame buffer added a new method in libmp4 to take two buffers, i.e. modified nalu seprators buffer and the incremented frame buffer pointer.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
