### PR TITLE
MultimediaQueue pace maker

### DIFF
--- a/base/include/BoundBuffer.h
+++ b/base/include/BoundBuffer.h
@@ -38,6 +38,25 @@ public:
 		}
 	}
 
+	void push_back(typename boost::call_traits<value_type>::param_type item)
+	{ // `param_type` represents the "best" way to pass a parameter of type `value_type` to a method.
+
+		boost::mutex::scoped_lock lock(m_mutex);
+		m_not_full.wait(lock, boost::bind(&bounded_buffer<value_type>::is_ready_to_accept, this));
+		if (is_not_full() && m_accept)
+		{
+			m_container.push_back(item);
+			++m_unread;
+			lock.unlock();
+			m_not_empty.notify_one();
+		}
+		else
+		{
+			// check and remove if explicit unlock is required
+			lock.unlock();
+		}
+	}
+
 	void push_drop_oldest(typename boost::call_traits<value_type>::param_type item)
 	{ 
 		boost::mutex::scoped_lock lock(m_mutex);

--- a/base/include/FrameContainerQueue.h
+++ b/base/include/FrameContainerQueue.h
@@ -8,6 +8,7 @@ class FrameContainerQueue :public bounded_buffer<frame_container> {
 public:
 	FrameContainerQueue(size_t capacity);
 	virtual void push(frame_container item);
+	virtual void push_back(frame_container item);
 	virtual void push_drop_oldest(frame_container item);
 	virtual frame_container pop();
 

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -221,7 +221,7 @@ protected:
 	}
 
 	template<class T>
-	bool queueCommand(T& cmd)
+	bool queueCommand(T& cmd, bool priority = false)
 	{
 		auto size = cmd.getSerializeSize();
 		auto frame = makeCommandFrame(size, mCommandMetadata);
@@ -231,7 +231,14 @@ protected:
 		// add to que
 		frame_container frames;
 		frames.insert(make_pair("command", frame));
-		Module::push(frames);
+		if (priority)
+		{
+			Module::push_back(frames);
+		}
+		else
+		{
+			Module::push(frames);
+		}
 
 		return true;
 	}
@@ -345,6 +352,7 @@ private:
 	void setSieveDisabledFlag(bool sieve);
 	frame_sp makeFrame(size_t size, framefactory_sp& framefactory);
 	bool push(frame_container frameContainer); //exchanges the buffer 
+	bool push_back(frame_container frameContainer);
 	bool try_push(frame_container frameContainer); //tries to exchange the buffer
 	
 	bool addEoPFrame(frame_container& frames);

--- a/base/include/MultimediaQueueXform.h
+++ b/base/include/MultimediaQueueXform.h
@@ -50,9 +50,12 @@ protected:
 	bool validateInputPins();
 	bool validateOutputPins();
 	bool validateInputOutputPins();
-
+	boost::shared_ptr<FrameContainerQueue> getQue();
+	void enqueueFramesAndProcessCommandFrame();
 private:
 	void getQueueBoundaryTS(uint64_t& tOld, uint64_t& tNew);
+	void pacerStart();
+	void pacerEnd();
 	std::string mOutputPinId;
 	bool pushToNextModule = true;
 	bool reset = false;
@@ -61,4 +64,10 @@ private:
 	uint64_t queryStartTime = 0;
 	uint64_t queryEndTime = 0;
 	FrameMetadata::FrameType mFrameType;
+	using sys_clock = std::chrono::system_clock;
+	sys_clock::time_point frame_begin;
+	std::chrono::nanoseconds myTargetFrameLen;
+	std::chrono::nanoseconds myNextWait;
+	uint64_t latestFrameExportedFromHandleCmd = 0;
+	bool initDone = false;
 };

--- a/base/src/FrameContainerQueue.cpp
+++ b/base/src/FrameContainerQueue.cpp
@@ -9,6 +9,11 @@ void FrameContainerQueue::push(frame_container item)
 	bounded_buffer<frame_container>::push(item);
 }
 
+void FrameContainerQueue::push_back(frame_container item)
+{
+	bounded_buffer<frame_container>::push_back(item);
+}
+
 void FrameContainerQueue::push_drop_oldest(frame_container item)
 {
 	bounded_buffer<frame_container>::push_drop_oldest(item);

--- a/base/src/Module.cpp
+++ b/base/src/Module.cpp
@@ -561,6 +561,12 @@ bool Module::push(frame_container frameContainer)
 	return true;
 }
 
+bool Module::push_back(frame_container frameContainer)
+{
+	mQue->push_back(frameContainer);
+	return true;
+}
+
 bool Module::try_push(frame_container frameContainer)
 {
 	auto rc = mQue->try_push(frameContainer);
@@ -1083,7 +1089,7 @@ bool Module::relay(boost::shared_ptr<Module> next, bool open)
 	}
 
 	auto cmd = RelayCommand(nextModuleId, open);
-	return queueCommand(cmd);
+	return queueCommand(cmd, true);
 }
 
 void Module::flushQueRecursive()


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Added pace maker in mmq , earlier since mmq was sending frames in a for loop it was not matching source's fps , made changes in the mmq to send frames according to source's fps.

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
