### PR TITLE
Rtsp module (SPS and PPS prepend changes)

### DIFF
--- a/base/src/RTSPClientSrc.cpp
+++ b/base/src/RTSPClientSrc.cpp
@@ -5,7 +5,6 @@
 
 using namespace std;
 
-
 #include <iostream>
 #include <string>
 
@@ -38,24 +37,23 @@ FrameMetadata::FrameType getFrameType_fromFFMPEG(AVMediaType avMediaType, AVCode
         case AV_CODEC_ID_BMP:
             return FrameMetadata::BMP_IMAGE;
         default:
-            return  FrameMetadata::GENERAL;
+            return FrameMetadata::GENERAL;
         }
     }
-    return  FrameMetadata::GENERAL; //for everything else we may not have a match
+    return FrameMetadata::GENERAL; // for everything else we may not have a match
 }
-
 
 class RTSPClientSrc::Detail
 {
 public:
-    Detail(RTSPClientSrc* m,std::string path, bool useTCP) :myModule(m), path(path), bConnected(false), bUseTCP(useTCP){}
+    Detail(RTSPClientSrc *m, std::string path, bool useTCP) : myModule(m), path(path), bConnected(false), bUseTCP(useTCP) {}
     ~Detail() { destroy(); }
     void destroy()
     {
-        if(nullptr!= pFormatCtx)
+        if (nullptr != pFormatCtx)
             avformat_close_input(&pFormatCtx);
     }
-    
+
     bool connect()
     {
         avformat_network_init();
@@ -63,14 +61,14 @@ public:
 
         pFormatCtx = avformat_alloc_context();
 
-        AVDictionary* avdic = NULL;
+        AVDictionary *avdic = NULL;
 
-        av_dict_set(&avdic, "rtsp_transport", (bUseTCP)?"tcp":"udp", 0);
+        av_dict_set(&avdic, "rtsp_transport", (bUseTCP) ? "tcp" : "udp", 0);
         av_dict_set(&avdic, "max_delay", "100", 0);
 
         if (avformat_open_input(&pFormatCtx, path.c_str(), NULL, &avdic) != 0)
         {
-            LOG_ERROR << "can't open the URL." << path <<std::endl;
+            LOG_ERROR << "can't open the URL." << path << std::endl;
             bConnected = false;
             return bConnected;
         }
@@ -82,27 +80,27 @@ public:
             return bConnected;
         }
 
-        //this loop should check that each output pin is satisfied
+        // this loop should check that each output pin is satisfied
         for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++)
         {
             auto pCodecCtx = pFormatCtx->streams[i]->codec;
-            LOG_INFO << av_get_media_type_string (pCodecCtx->codec_type)<<" Codec: " << avcodec_get_name(pCodecCtx->codec_id);
-            auto fType=getFrameType_fromFFMPEG(pCodecCtx->codec_type,pCodecCtx->codec_id);
-            string outPin=myModule->getOutputPinIdByType(fType);
+            LOG_INFO << av_get_media_type_string(pCodecCtx->codec_type) << " Codec: " << avcodec_get_name(pCodecCtx->codec_id);
+            auto fType = getFrameType_fromFFMPEG(pCodecCtx->codec_type, pCodecCtx->codec_id);
+            string outPin = myModule->getOutputPinIdByType(fType);
             if (!outPin.empty())
             {
                 streamsMap[i] = outPin;
                 if (pCodecCtx->codec_type == AVMEDIA_TYPE_VIDEO)
                 {
                     videoStream = i;
-                    auto meta= FrameMetadataFactory::downcast<H264Metadata>(myModule->getOutputMetadata(outPin));
+                    auto meta = FrameMetadataFactory::downcast<H264Metadata>(myModule->getOutputMetadata(outPin));
                     H264Metadata tmp(pCodecCtx->width, pCodecCtx->height, pCodecCtx->gop_size, pCodecCtx->max_b_frames);
                     meta->setData(tmp);
                 }
             }
         }
 
-        //by this time all the output pins should be satisfied if not we have a problem
+        // by this time all the output pins should be satisfied if not we have a problem
         if (streamsMap.size() < myModule->getNumberOfOutputPins())
         {
             LOG_ERROR << "some output pins can not be satsified" << std::endl;
@@ -119,7 +117,7 @@ public:
         size_t totalFrameSize = packet.size + spsPpsSize;
 
         auto frm = myModule->makeFrame(totalFrameSize, id);
-        uint8_t* frameData = static_cast<uint8_t*>(frm->data());
+        uint8_t *frameData = static_cast<uint8_t *>(frm->data());
         memcpy(frameData, spsPpsData, spsPpsSize);
         frameData += spsPpsSize;
         memcpy(frameData, packet.data, packet.size);
@@ -130,31 +128,32 @@ public:
     {
         frame_container outFrames;
         bool got_something = false;
-        while(!got_something)
+        while (!got_something)
         {
             if (av_read_frame(pFormatCtx, &packet) >= 0)
             {
-                if (videoStream >= 0) //source has video
+                if (videoStream >= 0) // source has video
                 {
-                    if (packet.stream_index == videoStream) //got video
+                    if (packet.stream_index == videoStream) // got video
                     {
                         got_something = true;
                     }
                 }
                 else
                 {
-                    got_something = true; //does not need video and got something
+                    got_something = true; // does not need video and got something
                 }
                 auto it = streamsMap.find(packet.stream_index);
-                if (it != streamsMap.end()) { // so we have an interest in sending this
+                if (it != streamsMap.end())
+                { // so we have an interest in sending this
                     frame_sp frm;
-                    auto naluType = H264Utils::getNALUType((const char*)packet.data);
+                    auto naluType = H264Utils::getNALUType((const char *)packet.data);
                     if (naluType == H264Utils::H264_NAL_TYPE_SEI)
                     {
                         size_t offset = 0;
                         packet.data += 4;
                         packet.size -= 4;
-                        H264Utils::getNALUnit((const char*)packet.data, packet.size, offset);
+                        H264Utils::getNALUnit((const char *)packet.data, packet.size, offset);
                         packet.data += offset - 4;
                         packet.size -= offset - 4;
                         frm = prependSpsPpsToFrame(it->second);
@@ -170,7 +169,7 @@ public:
                     }
 
                     std::chrono::time_point<std::chrono::system_clock> t = std::chrono::system_clock::now();
-                	auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
+                    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
                     frm->timestamp = dur.count();
                     if (!outFrames.insert(make_pair(it->second, frm)).second)
                     {
@@ -180,8 +179,8 @@ public:
                 av_packet_unref(&packet);
             }
         }
-        if(outFrames.size()>0)
-           myModule->send(outFrames);
+        if (outFrames.size() > 0)
+            myModule->send(outFrames);
         return true;
     }
 
@@ -189,48 +188,54 @@ public:
 
 private:
     AVPacket packet;
-    AVFormatContext* pFormatCtx = nullptr;
+    AVFormatContext *pFormatCtx = nullptr;
     std::string path;
     bool bConnected;
-    int videoStream=-1;
+    int videoStream = -1;
     bool bUseTCP;
     std::map<unsigned int, std::string> streamsMap;
-    RTSPClientSrc* myModule;
+    RTSPClientSrc *myModule;
 };
 
 RTSPClientSrc::RTSPClientSrc(RTSPClientSrcProps _props) : Module(SOURCE, "RTSPClientSrc", _props), mProps(_props)
 {
-    mDetail.reset(new Detail(this,mProps.rtspURL, mProps.useTCP));
+    mDetail.reset(new Detail(this, mProps.rtspURL, mProps.useTCP));
 }
-RTSPClientSrc::~RTSPClientSrc() {
+RTSPClientSrc::~RTSPClientSrc()
+{
 }
-bool RTSPClientSrc::init() {
+bool RTSPClientSrc::init()
+{
     if (mDetail->connect())
     {
         return Module::init();
     }
     return false;
 }
-bool RTSPClientSrc::term() {
+bool RTSPClientSrc::term()
+{
     mDetail.reset();
     return true;
 }
-void RTSPClientSrc::setProps(RTSPClientSrcProps& props)
+void RTSPClientSrc::setProps(RTSPClientSrcProps &props)
 {
     mProps = props;
-    //TBD need to also reset the whole connection
+    // TBD need to also reset the whole connection
 }
-RTSPClientSrcProps RTSPClientSrc::getProps() {
+RTSPClientSrcProps RTSPClientSrc::getProps()
+{
     return mProps;
 }
 
-bool RTSPClientSrc::produce() { 
+bool RTSPClientSrc::produce()
+{
     return mDetail->readBuffer();
 }
-bool RTSPClientSrc::validateOutputPins() { 
-    //smallest check at least one output pin should be there
+bool RTSPClientSrc::validateOutputPins()
+{
+    // smallest check at least one output pin should be there
     return this->getNumberOfOutputPins() > 0;
 }
 void RTSPClientSrc::notifyPlay(bool play) {}
-bool RTSPClientSrc::handleCommand(Command::CommandType type, frame_sp& frame) { return true; }
-bool RTSPClientSrc::handlePropsChange(frame_sp& frame) { return true; }
+bool RTSPClientSrc::handleCommand(Command::CommandType type, frame_sp &frame) { return true; }
+bool RTSPClientSrc::handlePropsChange(frame_sp &frame) { return true; }

--- a/base/src/RTSPClientSrc.cpp
+++ b/base/src/RTSPClientSrc.cpp
@@ -2,6 +2,7 @@
 #include "FrameMetadataFactory.h"
 #include "FrameMetadata.h"
 #include "H264Metadata.h"
+#include "H264Utils.h"
 
 using namespace std;
 
@@ -131,11 +132,35 @@ public:
                 }
                 auto it = streamsMap.find(packet.stream_index);
                 if (it != streamsMap.end()) { // so we have an interest in sending this
-                    auto frm=myModule->makeFrame(packet.size, it->second);
+                     frame_sp frm;
+                    auto naluType = H264Utils::getNALUType((const char*)packet.data);
+                    if (naluType == H264Utils::H264_NAL_TYPE_SEI)
+                    {
+                        size_t offset = 0;
+                        packet.data += 4;
+                        packet.size -= 4;
+                        H264Utils::getNALUnit((const char*)packet.data, packet.size, offset);
+                        packet.data += offset - 4;
+                        packet.size -= offset - 4;
+                        auto spsPpsData = pFormatCtx->streams[0]->codec->extradata;
+                        auto spsPpsSize = pFormatCtx->streams[0]->codec->extradata_size;;
+                        size_t totalFrameSize = packet.size + spsPpsSize;
+                       
+                        frm = myModule->makeFrame(totalFrameSize, it->second);
+                        uint8_t* frameData = static_cast<uint8_t*>(frm->data());
+                        memcpy(frameData, spsPpsData, spsPpsSize);
+                        frameData += spsPpsSize;
+                        memcpy(frameData, packet.data, packet.size);
+                    }
+                    else
+                    {
+                        frm = myModule->makeFrame(packet.size, it->second);
+                        memcpy(frm->data(), packet.data, packet.size);
+                    }
 
-                    //dreaded memory copy should be avoided
-                    memcpy(frm->data(), packet.data, packet.size);
-                    frm->timestamp = packet.pts;
+                    std::chrono::time_point<std::chrono::system_clock> t = std::chrono::system_clock::now();
+                	auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch());
+                    frm->timestamp = dur.count();
                     if (!outFrames.insert(make_pair(it->second, frm)).second)
                     {
                         LOG_WARNING << "oops! there is already another packet for pin " << it->second;

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "73fd815f46855d24cba85dd4a28af0b395960285",
+  "builtin-baseline": "93200f54eaa7cdbac5818443cd59079950cc52b7",
   "dependencies": [
     {
       "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "356814e3b10f457f01d9dfdc45e1b2cac0ff6b60",
+  "builtin-baseline": "73fd815f46855d24cba85dd4a28af0b395960285",
   "dependencies": [
     {
       "name": "opencv4",


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**
There was a problem in decoding h264 frame got using axis camera url, Resolved the issue in this PR . Basically while fetching frames using axis camera url , the sps and pps comes separately in extradata buffer and not along with frame, made changes in the module to prepend sps and pps with the frame.

Precise description of the changes in this pull request

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
