### PR TITLE
Mp4Reader - Fixed high resolution video playback issue

### DIFF
--- a/.github/workflows/build-test-win.yml
+++ b/.github/workflows/build-test-win.yml
@@ -41,7 +41,7 @@ on:
       bootstrap-cmd:
         type: string
         description: 'commands required to boot strap builder after code checkout'
-        default: './vcpkg/bootstrap-vcpkg.bat && ./vcpkg/vcpkg.exe integrate install --debug'
+        default: './vcpkg/bootstrap-vcpkg.bat && ./vcpkg/vcpkg.exe integrate install'
         required: false
       is-prep-phase:
         type: boolean

--- a/.github/workflows/build-test-win.yml
+++ b/.github/workflows/build-test-win.yml
@@ -110,8 +110,8 @@ jobs:
         cat submodule_ver.txt
         git rev-list --all --count 
 
-    - name: Run VCPKG bootstrap
-      run: ${{ inputs.bootstrap-cmd }}
+    - name: Run VCPKG bootstrap with debug mode
+      run: ${{ inputs.bootstrap-cmd }} DEBUG
 
     - name: Remove CUDA from vcpkg if we are in nocuda
       if: ${{ contains(inputs.cuda,'OFF')}} 

--- a/.github/workflows/build-test-win.yml
+++ b/.github/workflows/build-test-win.yml
@@ -41,7 +41,7 @@ on:
       bootstrap-cmd:
         type: string
         description: 'commands required to boot strap builder after code checkout'
-        default: './vcpkg/bootstrap-vcpkg.bat && ./vcpkg/vcpkg.exe integrate install'
+        default: './vcpkg/bootstrap-vcpkg.bat && ./vcpkg/vcpkg.exe integrate install --debug'
         required: false
       is-prep-phase:
         type: boolean
@@ -110,8 +110,8 @@ jobs:
         cat submodule_ver.txt
         git rev-list --all --count 
 
-    - name: Run VCPKG bootstrap with debug mode
-      run: ${{ inputs.bootstrap-cmd }} DEBUG
+    - name: Run VCPKG bootstrap
+      run: ${{ inputs.bootstrap-cmd }}
 
     - name: Remove CUDA from vcpkg if we are in nocuda
       if: ${{ contains(inputs.cuda,'OFF')}} 

--- a/base/include/Mp4WriterSinkUtils.h
+++ b/base/include/Mp4WriterSinkUtils.h
@@ -1,4 +1,7 @@
 #include <ctime>
+#include <chrono>
+#include <string>
+#include <boost/filesystem.hpp>
 
 class Mp4WriterSinkUtils
 {

--- a/base/src/Mp4ReaderSource.cpp
+++ b/base/src/Mp4ReaderSource.cpp
@@ -1256,11 +1256,15 @@ bool Mp4ReaderDetailH264::produceFrames(frame_container& frames)
 	{
 		frameData[3] = 0x1;
 		frameData[spsSize + 7] = 0x1;
+		frameData[spsSize + ppsSize + 8] = 0x0;
+		frameData[spsSize + ppsSize + 9] = 0x0;
 		frameData[spsSize + ppsSize + 10] = 0x0;
 		frameData[spsSize + ppsSize + 11] = 0x1;
 	}
 	else
 	{
+		frameData[0] = 0x0;
+		frameData[1] = 0x0;
 		frameData[2] = 0x0;
 		frameData[3] = 0x1;
 	}

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "b26b6b9275d9b4584a07d9ed9f9fcbb06b1e3961",
+  "builtin-baseline": "31fd6b8d7bdfd989059cc884bcb06c6a81f454aa",
   "dependencies": [
     {
       "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "6343c2b86606d16411b79571afe2ea799a438314",
+  "builtin-baseline": "46cf263b3d4bfab6d322b47ab40222db167c28b1",
   "dependencies": [
     {
       "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "b0fcdddda95f07f1537c2dac5cd77fdc32fe31e2",
+  "builtin-baseline": "b26b6b9275d9b4584a07d9ed9f9fcbb06b1e3961",
   "dependencies": [
     {
       "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "31fd6b8d7bdfd989059cc884bcb06c6a81f454aa",
+  "builtin-baseline": "6343c2b86606d16411b79571afe2ea799a438314",
   "dependencies": [
     {
       "name": "opencv4",

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "356814e3b10f457f01d9dfdc45e1b2cac0ff6b60",
+  "builtin-baseline": "b0fcdddda95f07f1537c2dac5cd77fdc32fe31e2",
   "dependencies": [
     {
       "name": "opencv4",


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**

In the Mp4reader (h264), The PR fixes the  issue of decoding frames with high resolution. In the Mp4Reader we convert the mp4 format nalu separator to standard H.264 nalu format, earlier we were only converting last two bytes of nalu separator to standard format where the frame's size is written, but for the high resolution video where the frame's size is greater than 2 ^ 16 , 3 bytes of nalu separator were getting used and because of that one byte was not getting converted. Updated the code to convert all 4 bytes of nalu separator to standard H.264 format./

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix )

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
