### PR TITLE
Removed the next pointer offset condition to set data size

### DIFF
--- a/base/include/RawImagePlanarMetadata.h
+++ b/base/include/RawImagePlanarMetadata.h
@@ -151,11 +151,8 @@ protected:
 		dataSize = 0;
 		for (auto i = 0; i < channels; i++)
 		{
-			if (nextPtrOffset[i] == NOT_SET_NUM)
-			{
-				nextPtrOffset[i] = dataSize;
-				dataSize += step[i] * height[i];
-			}
+			nextPtrOffset[i] = dataSize;
+			dataSize += step[i] * height[i];
 		}
 	}
 


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**

Fixed the issue of data size not getting set for the 2nd time due to nextPtrOffset (condition where we were checking if the value is same is declared value) variable getting initialized while setting data size for the first time.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
