### PR TITLE
Added a function to reset the image size

### DIFF
--- a/base/include/VirtualCameraSink.h
+++ b/base/include/VirtualCameraSink.h
@@ -22,6 +22,7 @@ public:
 	bool term();
 
 	void getImageSize(int &width, int &height);
+	void resetImageSize();
 
 protected:
 	bool process(frame_container &frames);

--- a/base/src/VirtualCameraSink.cpp
+++ b/base/src/VirtualCameraSink.cpp
@@ -272,3 +272,8 @@ void VirtualCameraSink::getImageSize(int &width, int &height)
 {
 	mDetail->getImageSize(width, height);
 }
+
+void VirtualCameraSink::resetImageSize()
+{
+	mDetail->imageSize = 0;
+}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**

Added a function to reset the image size of the virtual cam device, so that processSos() hits in the next step to change the resolution of the virtual device.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Feature)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
