### PR TITLE
Playback speed control feature

### DIFF
--- a/base/include/Command.h
+++ b/base/include/Command.h
@@ -27,7 +27,8 @@ public:
 		MMQtimestamps,
 		Rendertimestamp,
 		RenderPlayPause,
-		Mp4ErrorHandle
+		Mp4ErrorHandle,
+		DecoderPlaybackSpeed,
 	};
 
 	Command()
@@ -645,5 +646,31 @@ private:
 		ar& boost::serialization::base_object<Command>(*this);
 		ar& previousFile;
 		ar& nextFile;
+	}
+};
+
+class DecoderPlaybackSpeed : public Command
+{
+public:
+	DecoderPlaybackSpeed() : Command(Command::CommandType::DecoderPlaybackSpeed)
+	{
+	}
+
+	size_t getSerializeSize()
+	{
+		return Command::getSerializeSize() + sizeof(playbackFps) + sizeof(playbackSpeed);
+	}
+
+	int playbackFps;
+	float playbackSpeed;
+
+private:
+	friend class boost::serialization::access;
+	template<class Archive>
+	void serialize(Archive& ar, const unsigned int /* file_version */)
+	{
+		ar& boost::serialization::base_object<Command>(*this);
+		ar& playbackFps;
+		ar& playbackSpeed;
 	}
 };

--- a/base/include/Command.h
+++ b/base/include/Command.h
@@ -658,11 +658,12 @@ public:
 
 	size_t getSerializeSize()
 	{
-		return Command::getSerializeSize() + sizeof(playbackFps) + sizeof(playbackSpeed);
+		return Command::getSerializeSize() + sizeof(playbackFps) + sizeof(playbackSpeed) + sizeof(gop);
 	}
 
 	int playbackFps;
 	float playbackSpeed;
+	int gop;
 
 private:
 	friend class boost::serialization::access;

--- a/base/include/H264Decoder.h
+++ b/base/include/H264Decoder.h
@@ -76,7 +76,9 @@ private:
 	boost::asio::const_buffer ppsBuffer;
 	std::mutex m;
 	int framesToSkip = 0;
+	int iFramesToSkip = 0;
 	int currentFps = 24;
 	int previousFps = 24;
 	float playbackSpeed = 1;
+	int gop;
 };

--- a/base/include/H264Decoder.h
+++ b/base/include/H264Decoder.h
@@ -32,6 +32,7 @@ protected:
 	bool validateOutputPins();
 	bool shouldTriggerSOS();
 	void flushQue();
+	bool handleCommand(Command::CommandType type, frame_sp& frame);
 
 private:
 	void bufferDecodedFrames(frame_sp& frame);
@@ -74,4 +75,8 @@ private:
 	boost::asio::const_buffer spsBuffer;
 	boost::asio::const_buffer ppsBuffer;
 	std::mutex m;
+	int framesToSkip = 0;
+	int currentFps = 24;
+	int previousFps = 24;
+	float playbackSpeed = 1;
 };

--- a/base/include/Mp4ReaderSource.h
+++ b/base/include/Mp4ReaderSource.h
@@ -124,6 +124,7 @@ public:
 	double getOpenVideoFPS();
 	double getOpenVideoDurationInSecs();
 	int32_t getOpenVideoFrameCount();
+	void setPlaybackSpeed(float _playbckSpeed);
 	void getResolution(uint32_t& width, uint32_t& height)
 	{
 		width = mWidth;

--- a/base/include/Mp4WriterSinkUtils.h
+++ b/base/include/Mp4WriterSinkUtils.h
@@ -1,4 +1,7 @@
 #include <ctime>
+#include <chrono>
+#include <string>
+#include <boost/filesystem.hpp>
 
 class Mp4WriterSinkUtils
 {

--- a/base/include/MultimediaQueueXform.h
+++ b/base/include/MultimediaQueueXform.h
@@ -25,6 +25,29 @@ public:
 	uint32_t upperWaterMark; //Length of the multimedia queue when the next module queue is full
 	bool isMapDelayInTime;
 	int mmqFps;
+
+	size_t getSerializeSize()
+	{
+		return ModuleProps::getSerializeSize() + sizeof(lowerWaterMark) + sizeof(upperWaterMark) + sizeof(isMapDelayInTime) + sizeof(mmqFps);
+	}
+
+	int startIndex;
+	int maxIndex;
+	string strFullFileNameWithPattern;
+	bool readLoop;
+
+private:
+	friend class boost::serialization::access;
+
+	template<class Archive>
+	void serialize(Archive &ar, const unsigned int version)
+	{
+		ar & boost::serialization::base_object<ModuleProps>(*this);
+		ar & lowerWaterMark;
+		ar & upperWaterMark;
+		ar & isMapDelayInTime;
+		ar & mmqFps;
+	}
 };
 
 class State;
@@ -49,6 +72,7 @@ public:
 	boost::shared_ptr<FrameContainerQueue> getQue();
 	void extractFramesAndEnqueue(boost::shared_ptr<FrameContainerQueue>& FrameQueue);
 	void setMmqFps(int fps);
+	void setPlaybackSpeed(float playbackSpeed);
 protected:
 	bool process(frame_container& frames);
 	bool validateInputPins();
@@ -73,4 +97,7 @@ private:
 	uint64_t latestFrameExportedFromHandleCmd = 0;
 	uint64_t latestFrameExportedFromProcess = 0;
 	bool initDone = false;
+	int framesToSkip = 0;
+	int initialFps = 0;
+	float speed = 1;
 };

--- a/base/src/Mp4ReaderSource.cpp
+++ b/base/src/Mp4ReaderSource.cpp
@@ -507,10 +507,13 @@ public:
 				mFPS = mState.mFramesInVideo / mDurationInSecs;
 				if ((controlModule != nullptr))
 				{
-					mProps.fps = mFPS;
-					LOG_INFO << "fps of new video is = " << mFPS;
+					mProps.fps = mFPS * playbackSpeed;
+					LOG_INFO << "fps of new video is = " << mProps.fps;
 					setMp4ReaderProps(mProps);
 					LOG_INFO << "did set Mp4reader props";	
+					DecoderPlaybackSpeed cmd;
+					cmd.playbackSpeed = playbackSpeed;
+					cmd.playbackFps = mFPS;
 				}
 			}
 		}
@@ -1080,6 +1083,7 @@ public:
 	bool isMp4SeekFrame = false;
 	int ret;
 	double mFPS = 0;
+	float playbackSpeed = 1;
 	double mDurationInSecs = 0;
 	std::function<frame_sp(size_t size, string& pinId)> makeFrame;
 	std::function<void(frame_sp frame)> sendEOS;
@@ -1624,4 +1628,9 @@ bool Mp4ReaderSource::randomSeek(uint64_t skipTS, bool forceReopen)
 {
 	Mp4SeekCommand cmd(skipTS, forceReopen);
 	return queueCommand(cmd);
+}
+
+void Mp4ReaderSource::setPlaybackSpeed(float _playbackSpeed)
+{
+	mDetail->playbackSpeed = _playbackSpeed;
 }

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "apra-pipes-cuda",
   "version": "0.0.1",
-  "builtin-baseline": "356814e3b10f457f01d9dfdc45e1b2cac0ff6b60",
+  "builtin-baseline": "aa2bb6dcdaac6c44c487c8bebfbdab1198c09026",
   "dependencies": [
     {
       "name": "opencv4",


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

**Description**
Implemented feature to supoort change of speed playaback speed dynamically . The range of speed are from 0.5x to 32x

Precise description of the changes in this pull request

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
