### PR TITLE
Time muxer strategy

### DIFF
--- a/base/include/FramesMuxer.h
+++ b/base/include/FramesMuxer.h
@@ -16,7 +16,7 @@ public:
 	{
 		maxTsDelayInMS = 16.67;
 		maxDelay = 30;
-		strategy = MAX_TIMESTAMP_DELAY;
+		strategy = ALL_OR_NONE;
 		fIndexStrategyType = FIndexStrategy::FIndexStrategyType::NONE;
 	}
 

--- a/base/include/FramesMuxer.h
+++ b/base/include/FramesMuxer.h
@@ -7,18 +7,22 @@ class FramesMuxerProps : public ModuleProps
 public:
 	enum Strategy {
 		ALL_OR_NONE,
-		MAX_DELAY_ANY
+		MAX_DELAY_ANY,
+		MAX_TIMESTAMP_DELAY
 	};
+
 public:
-	FramesMuxerProps() : ModuleProps() 
+	FramesMuxerProps() : ModuleProps()
 	{
+		maxTsDelayInMS = 16.67;
 		maxDelay = 30;
-		strategy = ALL_OR_NONE;
+		strategy = MAX_TIMESTAMP_DELAY;
 		fIndexStrategyType = FIndexStrategy::FIndexStrategyType::NONE;
 	}
 
 	int maxDelay; // Difference between current frame and first frame in the queue
 	Strategy strategy;
+	double maxTsDelayInMS; // Max TimeStampDelay in Milli Seconds
 };
 
 class FramesMuxerStrategy;

--- a/base/src/FramesMuxer.cpp
+++ b/base/src/FramesMuxer.cpp
@@ -334,6 +334,101 @@ private:
 };
 
 
+class TimeStampStrategy : public FramesMuxerStrategy
+{
+
+public:
+	TimeStampStrategy(FramesMuxerProps& _props) :FramesMuxerStrategy(_props), maxTsDelayInMS(_props.maxTsDelayInMS) {}
+
+	~TimeStampStrategy()
+	{
+		clear();
+	}
+
+	std::string addInputPin(std::string& pinId)
+	{
+		mQueue[pinId] = boost::container::deque<frame_sp>();
+
+		return FramesMuxerStrategy::addInputPin(pinId);
+	}
+
+	bool queue(frame_container& frames)
+	{
+		double largestTimeStamp = 0;
+		for (auto it = frames.cbegin(); it != frames.cend(); it++)
+		{
+			mQueue[it->first].push_back(it->second);
+			if (largestTimeStamp < it->second->timestamp)
+			{
+				largestTimeStamp = it->second->timestamp;
+			}
+		}
+
+		for (auto it = mQueue.begin(); it != mQueue.end(); it++)
+		{
+			auto& frames_arr = it->second;
+			while (frames_arr.size())
+			{
+				auto& frame = frames_arr.front();
+				if (largestTimeStamp - frame->timestamp > maxTsDelayInMS)
+				{
+					frames_arr.pop_front();
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+		return true;
+	}
+
+	bool get(frame_container& frames)
+	{
+		bool allFound = true;
+		size_t fIndex = 0;
+		bool firstIter = true;
+
+		for (auto it = mQueue.begin(); it != mQueue.end(); it++)
+		{
+			auto& frames_arr = it->second;
+			if (frames_arr.size() == 0)
+			{
+				allFound = false;
+				break;
+			}
+		}
+
+		if (!allFound)
+		{
+			return false;
+		}
+		for (auto it = mQueue.begin(); it != mQueue.end(); it++)
+		{
+			frames[FramesMuxerStrategy::getMuxOutputPinId(it->first)] = it->second.front();
+			it->second.pop_front();
+		}
+		return true;
+	}
+
+	void clear()
+	{
+		for (auto it = mQueue.begin(); it != mQueue.end(); it++)
+		{
+			it->second.clear();
+		}
+		mQueue.clear();
+	}
+
+private:
+
+	typedef std::map<std::string, boost_deque<frame_sp>> MuxerQueue;
+	MuxerQueue mQueue;
+	double maxTsDelayInMS;
+	int maxDelay;
+
+};
+
 FramesMuxer::FramesMuxer(FramesMuxerProps _props) :Module(TRANSFORM, "FramesMuxer", _props)
 {
 
@@ -345,6 +440,9 @@ FramesMuxer::FramesMuxer(FramesMuxerProps _props) :Module(TRANSFORM, "FramesMuxe
 	case FramesMuxerProps::MAX_DELAY_ANY:
 		mDetail.reset(new MaxDelayAnyStrategy(_props));
 		break;
+	case FramesMuxerProps::MAX_TIMESTAMP_DELAY:
+		mDetail.reset(new TimeStampStrategy(_props));
+		break;	
 	default:
 		LOG_ERROR << "Strategy not implemented " << _props.strategy;
 		break;

--- a/base/src/FramesMuxer.cpp
+++ b/base/src/FramesMuxer.cpp
@@ -354,7 +354,7 @@ public:
 
 	bool queue(frame_container& frames)
 	{
-		double largestTimeStamp = 0;
+		uint64_t largestTimeStamp = 0;
 		for (auto it = frames.cbegin(); it != frames.cend(); it++)
 		{
 			mQueue[it->first].push_back(it->second);

--- a/base/test/framesmuxer_tests.cpp
+++ b/base/test/framesmuxer_tests.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include <boost/test/unit_test.hpp>
+#include <chrono>
 
 #include "ExternalSourceModule.h"
 #include "ExternalSinkModule.h"
@@ -759,6 +760,203 @@ BOOST_AUTO_TEST_CASE(maxdelaystrategy_drop_flush)
 	m3.reset();
 	muxer.reset();
 	sink.reset();
+}
+
+BOOST_AUTO_TEST_CASE(timestamp_strategy)
+{
+    size_t readDataSize = 1024;
+
+    auto metadata = framemetadata_sp(new FrameMetadata(FrameMetadata::ENCODED_IMAGE));
+
+    auto m1 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin1_1 = m1->addOutputPin(metadata);
+
+    auto m2 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin2_1 = m2->addOutputPin(metadata);
+
+    auto m3 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin3_1 = m3->addOutputPin(metadata);
+
+    FramesMuxerProps props;
+    props.strategy = FramesMuxerProps::MAX_TIMESTAMP_DELAY;
+    auto muxer = boost::shared_ptr<Module>(new FramesMuxer(props));
+    m1->setNext(muxer);
+    m2->setNext(muxer);
+    m3->setNext(muxer);
+
+    auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+    muxer->setNext(sink);
+
+    BOOST_TEST(m1->init());
+    BOOST_TEST(m2->init());
+    BOOST_TEST(m3->init());
+
+    BOOST_TEST(muxer->init());
+    BOOST_TEST(sink->init());
+
+    {
+        // Send frames with the same timestamp
+        auto timestamp = std::chrono::system_clock::now().time_since_epoch().count();
+
+        auto encodedImageFrame1 = m1->makeFrame(readDataSize, pin1_1);
+        encodedImageFrame1->fIndex = 100;
+        encodedImageFrame1->timestamp = timestamp;
+
+        auto encodedImageFrame2 = m2->makeFrame(readDataSize, pin2_1);
+        encodedImageFrame2->fIndex = 100;
+        encodedImageFrame2->timestamp = timestamp;
+
+        auto encodedImageFrame3 = m3->makeFrame(readDataSize, pin3_1);
+        encodedImageFrame3->fIndex = 100;
+        encodedImageFrame3->timestamp = timestamp;
+
+        frame_container frames1;
+        frames1.insert(make_pair(pin1_1, encodedImageFrame1));
+        m1->send(frames1);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames2;
+        frames2.insert(make_pair(pin2_1, encodedImageFrame2));
+        m2->send(frames2);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames3;
+        frames3.insert(make_pair(pin3_1, encodedImageFrame3));
+        m3->send(frames3);
+        muxer->step();
+        auto outFrames = sink->try_pop();
+		BOOST_TEST(outFrames.size() == 3);
+
+        // Send frames with different timestamps
+        auto newTimestamp = timestamp + std::chrono::milliseconds(100).count();
+
+        auto encodedImageFrame4 = m1->makeFrame(readDataSize, pin1_1);
+        encodedImageFrame4->fIndex = 200;
+        encodedImageFrame4->timestamp = newTimestamp;
+
+        auto encodedImageFrame5 = m2->makeFrame(readDataSize, pin2_1);
+        encodedImageFrame5->fIndex = 200;
+        encodedImageFrame5->timestamp = newTimestamp;
+
+        auto encodedImageFrame6 = m3->makeFrame(readDataSize, pin3_1);
+        encodedImageFrame6->fIndex = 200;
+        encodedImageFrame6->timestamp = newTimestamp;
+
+        frames1.clear();
+        frames1.insert(make_pair(pin1_1, encodedImageFrame4));
+        m1->send(frames1);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frames2.clear();
+        frames2.insert(make_pair(pin2_1, encodedImageFrame5));
+        m2->send(frames2);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frames3.clear();
+        frames3.insert(make_pair(pin3_1, encodedImageFrame6));
+        m3->send(frames3);
+        muxer->step();
+        outFrames = sink->try_pop();
+    }
+
+    BOOST_TEST(m1->term());
+    BOOST_TEST(m2->term());
+    BOOST_TEST(m3->term());
+    BOOST_TEST(muxer->term());
+    BOOST_TEST(sink->term());
+
+    m1.reset();
+    m2.reset();
+    m3.reset();
+    muxer.reset();
+    sink.reset();
+}
+
+BOOST_AUTO_TEST_CASE(timestamp_strategy_with_maxdelay)
+{
+    size_t readDataSize = 1024;
+
+    auto metadata = framemetadata_sp(new FrameMetadata(FrameMetadata::ENCODED_IMAGE));
+
+    auto m1 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin1_1 = m1->addOutputPin(metadata);
+
+    auto m2 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin2_1 = m2->addOutputPin(metadata);
+
+    auto m3 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin3_1 = m3->addOutputPin(metadata);
+
+    FramesMuxerProps props;
+    props.strategy = FramesMuxerProps::MAX_TIMESTAMP_DELAY;
+    props.maxDelay = 100; // Max delay in milliseconds
+    auto muxer = boost::shared_ptr<Module>(new FramesMuxer(props));
+    m1->setNext(muxer);
+    m2->setNext(muxer);
+    m3->setNext(muxer);
+
+    auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+    muxer->setNext(sink);
+
+    BOOST_TEST(m1->init());
+    BOOST_TEST(m2->init());
+    BOOST_TEST(m3->init());
+
+    BOOST_TEST(muxer->init());
+    BOOST_TEST(sink->init());
+
+    {
+        // Send frames with timestamps differing by more than maxDelay
+        auto baseTimestamp = std::chrono::system_clock::now().time_since_epoch().count();
+
+        auto encodedImageFrame1 = m1->makeFrame(readDataSize, pin1_1);
+        encodedImageFrame1->fIndex = 300;
+        encodedImageFrame1->timestamp = baseTimestamp;
+
+        auto encodedImageFrame2 = m2->makeFrame(readDataSize, pin2_1);
+        encodedImageFrame2->fIndex = 300;
+        encodedImageFrame2->timestamp = baseTimestamp + std::chrono::milliseconds(150).count(); // 150 ms difference
+
+        auto encodedImageFrame3 = m3->makeFrame(readDataSize, pin3_1);
+        encodedImageFrame3->fIndex = 300;
+        encodedImageFrame3->timestamp = baseTimestamp;
+
+        frame_container frames1;
+        frames1.insert(make_pair(pin1_1, encodedImageFrame1));
+        m1->send(frames1);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames2;
+        frames2.insert(make_pair(pin2_1, encodedImageFrame2));
+        m2->send(frames2);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames3;
+        frames3.insert(make_pair(pin3_1, encodedImageFrame3));
+        m3->send(frames3);
+        muxer->step();
+        auto outFrames = sink->try_pop();
+        // Frames should not be muxed because of maxDelay
+        BOOST_TEST(outFrames.size() == 0);
+    }
+
+    BOOST_TEST(m1->term());
+    BOOST_TEST(m2->term());
+    BOOST_TEST(m3->term());
+    BOOST_TEST(muxer->term());
+    BOOST_TEST(sink->term());
+
+    m1.reset();
+    m2.reset();
+    m3.reset();
+    muxer.reset();
+    sink.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/framesmuxer_tests.cpp
+++ b/base/test/framesmuxer_tests.cpp
@@ -1036,4 +1036,93 @@ BOOST_AUTO_TEST_CASE(timestamp_strategy_with_maxdelay)
     sink.reset();
 }
 
+BOOST_AUTO_TEST_CASE(timestamp_strategy_with_negativeTImeDelay) // This test was added to test How Muxer Behave When A Frame From relative past was pushed into the queue 
+{
+    size_t readDataSize = 1024;
+
+    auto metadata = framemetadata_sp(new FrameMetadata(FrameMetadata::ENCODED_IMAGE));
+
+    auto m1 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin1_1 = m1->addOutputPin(metadata);
+
+    auto m2 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin2_1 = m2->addOutputPin(metadata);
+
+    auto m3 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+    auto pin3_1 = m3->addOutputPin(metadata);
+
+    FramesMuxerProps props;
+    props.strategy = FramesMuxerProps::MAX_TIMESTAMP_DELAY;
+    props.maxTsDelayInMS = 100; // Max delay in milliseconds
+    auto muxer = boost::shared_ptr<Module>(new FramesMuxer(props));
+    m1->setNext(muxer);
+    m2->setNext(muxer);
+    m3->setNext(muxer);
+
+    auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+    muxer->setNext(sink);
+
+    BOOST_TEST(m1->init());
+    BOOST_TEST(m2->init());
+    BOOST_TEST(m3->init());
+
+    BOOST_TEST(muxer->init());
+    BOOST_TEST(sink->init());
+
+    {
+        // Send frames with timestamps differing by more than maxDelay
+        auto baseTimestamp = std::chrono::system_clock::now().time_since_epoch().count();
+
+        auto encodedImageFrame1 = m1->makeFrame(readDataSize, pin1_1);
+        encodedImageFrame1->fIndex = 300;
+        encodedImageFrame1->timestamp = baseTimestamp;
+
+        auto encodedImageFrame2 = m2->makeFrame(readDataSize, pin2_1);
+        encodedImageFrame2->fIndex = 300;
+        encodedImageFrame2->timestamp = baseTimestamp + std::chrono::milliseconds(150).count(); // 150 ms difference
+
+        auto encodedImageFrame3 = m3->makeFrame(readDataSize, pin3_1);
+        encodedImageFrame3->fIndex = 300;
+        encodedImageFrame3->timestamp = baseTimestamp - std::chrono::milliseconds(150).count();
+
+        frame_container frames1;
+        frames1.insert(make_pair(pin1_1, encodedImageFrame1));
+        m1->send(frames1);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames2;
+        frames2.insert(make_pair(pin2_1, encodedImageFrame2));
+        m2->send(frames2);
+        muxer->step();
+        BOOST_TEST(sink->try_pop().size() == 0);
+
+        frame_container frames3;
+        frames3.insert(make_pair(pin3_1, encodedImageFrame3));
+        m3->send(frames3);
+        muxer->step();
+        auto outFrames = sink->try_pop();
+        // Frames should not be muxed because of maxDelay
+        BOOST_TEST(outFrames.size() == 0);
+    }
+
+    BOOST_TEST(m1->term());
+    BOOST_TEST(m2->term());
+    BOOST_TEST(m3->term());
+    BOOST_TEST(muxer->term());
+    BOOST_TEST(sink->term());
+
+    m1.reset();
+    m2.reset();
+    m3.reset();
+    muxer.reset();
+    sink.reset();
+}
+
+// To Do:- 
+// 1. Need to have Public Function To Get Curr State of Muxer
+// 2. Need to add more strategies
+// 3. Need to add more tests
+// 4. Need to add proper documentation for each of this strategy 
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/framesmuxer_tests.cpp
+++ b/base/test/framesmuxer_tests.cpp
@@ -283,7 +283,84 @@ BOOST_AUTO_TEST_CASE(allornone)
 	sink.reset();
 }
 
+BOOST_AUTO_TEST_CASE(allornone_sampling_by_drops) {
+	size_t readDataSize = 1024;
 
+	auto metadata =
+		framemetadata_sp(new FrameMetadata(FrameMetadata::ENCODED_IMAGE));
+
+	auto m1 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+	auto pin1_1 = m1->addOutputPin(metadata);
+	auto pin1_2 = m1->addOutputPin(metadata);
+
+	auto m2 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+	auto pin2_1 = m2->addOutputPin(metadata);
+
+	auto m3 = boost::shared_ptr<ExternalSourceModule>(new ExternalSourceModule());
+	auto pin3_1 = m3->addOutputPin(metadata);
+
+	// drop 3 out of 4 frames
+	auto muxProps = new FramesMuxerProps();
+	muxProps->skipN = 3;
+	muxProps->skipD = 4;
+
+	auto muxer = boost::shared_ptr<Module>(new FramesMuxer(*muxProps));
+	m1->setNext(muxer);
+	m2->setNext(muxer);
+	m3->setNext(muxer);
+
+	auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+	muxer->setNext(sink);
+
+	BOOST_TEST(m1->init());
+	BOOST_TEST(m2->init());
+	BOOST_TEST(m3->init());
+
+	BOOST_TEST(muxer->init());
+	BOOST_TEST(sink->init());
+
+	{
+		// basic
+		int countMuxOutput = 0;
+		int iterations = 4000;
+
+		auto encodedImageFrame = m1->makeFrame(readDataSize, pin1_1);
+		for (int i = 0; i < iterations; ++i)
+		{
+			encodedImageFrame->fIndex = 500 + i;
+
+			frame_container frames;
+			frames.insert(make_pair(pin1_1, encodedImageFrame));
+			frames.insert(make_pair(pin1_2, encodedImageFrame));
+			frames.insert(make_pair(pin2_1, encodedImageFrame));
+			frames.insert(make_pair(pin3_1, encodedImageFrame));
+
+			m1->send(frames);
+			muxer->step();
+			if ((i + 1) % 3 != 0)
+				BOOST_TEST(sink->try_pop().size() == 0);
+
+			m2->send(frames);
+			muxer->step();
+			if ((i + 1) % 3 != 0)
+				BOOST_TEST(sink->try_pop().size() == 0);
+
+			m3->send(frames);
+			muxer->step();
+			auto outFrames = sink->try_pop();
+			LOG_ERROR << "outFrames <" << outFrames.size() << ">";
+			if (outFrames.size())
+			{
+				countMuxOutput += 1;
+				testFrames(outFrames, 500 + i, 4);
+			}
+		}
+		LOG_ERROR << "COUNT MUX FRAMES OUTPUT <" << countMuxOutput << "> / " << iterations << ".";
+		float passThroughRatio = (muxProps->skipD - muxProps->skipN) / (float)muxProps->skipD;
+		BOOST_TEST(countMuxOutput == (iterations * passThroughRatio));
+
+	}
+}
 
 BOOST_AUTO_TEST_CASE(maxdelaystrategy_1)
 {


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**
The MaxDelayTimeStampStrategy is a component designed to manage the timing and synchronization of frames within a muxing system. Its primary function is to ensure that frames from multiple input sources are combined only if their timestamps are within a defined maximum delay threshold (maxTSDelay).

Key Features:

Timestamp-Based Synchronization: The strategy checks the timestamp difference between incoming frames and only processes frames that have a timestamp difference within the allowed maximum delay.

Flexibility: Configurable maxTSDelay allows adjustment of the acceptable delay between frames, accommodating various timing requirements and use cases.

This strategy helps maintain temporal coherence in the muxed output by filtering out frames that do not meet the timestamp criteria, thereby improving the accuracy and reliability of the muxing process.


**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | **Feature** | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
