### PR TITLE
Remove Baresip and libre, revert changes in H264Decoder and NvTransform specific to NVR and fix a memory leak in nvcodec decoder

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -92,8 +92,6 @@ IF(ENABLE_CUDA)
 		find_library(NVBUFUTILSLIB nvbuf_utils REQUIRED)
 		find_library(EGLSTREAM_CAMCONSUMER_LIB nveglstream_camconsumer REQUIRED)
 		find_library(NVARGUS_SOCKETCLINET_LIB nvargus_socketclient REQUIRED)
-		find_library(LIBRE_LIB NAMES libre.so libre.a REQUIRED)
-		find_library(BARESIP_LIB NAMES libbaresip.so REQUIRED)
 		find_package(Curses REQUIRED)
 
 		set(VCPKG_GTK_INCLUDE_DIRS
@@ -127,8 +125,6 @@ IF(ENABLE_CUDA)
 	ELSEIF(ENABLE_LINUX)
 		find_library(LIBNVCUVID libnvcuvid.so PATHS /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
 		find_library(LIBNVENCODE libnvidia-encode.so PATHS /usr/lib/x86_64-linux-gnu NO_DEFAULT_PATH)
-		find_library(LIBRE_LIB NAMES libre.so libre.a REQUIRED)
-		find_library(BARESIP_LIB NAMES libbaresip.so REQUIRED)
 		SET(NVCODEC_LIB ${LIBNVCUVID} ${LIBNVENCODE})
 		SET(NVCUDAToolkit_LIBS
 			libcuda.so		
@@ -512,8 +508,6 @@ target_include_directories ( aprapipes PRIVATE
 	${OpenCV_INCLUDE_DIRS} 
 	${Boost_INCLUDE_DIRS}
 	${LIBMP4_INC_DIR}
-	${BARESIP_INC_DIR}
-	${LIBRE_INC_DIR}
 	${NVCODEC_INCLUDE_DIR}
 )
 

--- a/base/include/PipeLine.h
+++ b/base/include/PipeLine.h
@@ -47,7 +47,7 @@ public:
 	void stop();
 	void term();
 	void wait_for_all(bool ignoreStatus = false);
-	void interrup_wait_for_all();
+	void interrupt_wait_for_all();
 	void flushAllQueues();
 	const char* getStatus();
 };

--- a/base/src/H264Decoder.cpp
+++ b/base/src/H264Decoder.cpp
@@ -735,10 +735,10 @@ bool H264Decoder::processEOS(string& pinId)
 {
 	//THIS HAS BEEN COMMENTED IN NVR - BECAUSE EOS IS SENT FROM MP4READER WHICH COMES TO DECODER AND THE FOLLOWING PROCESS IS NOT REQUIRED IN NVR. 
 	
-	// auto frame = frame_sp(new EmptyFrame());
-	// mDetail->compute(frame->data(), frame->size(), frame->timestamp);
-	// LOG_ERROR << "processes sos " ;
-	//mShouldTriggerSOS = true;
+	auto frame = frame_sp(new EmptyFrame());
+	mDetail->compute(frame->data(), frame->size(), frame->timestamp);
+	LOG_ERROR << "processes sos " ;
+	mShouldTriggerSOS = true;
 	return true;
 }
 

--- a/base/src/H264Decoder.cpp
+++ b/base/src/H264Decoder.cpp
@@ -735,10 +735,10 @@ bool H264Decoder::processEOS(string& pinId)
 {
 	//THIS HAS BEEN COMMENTED IN NVR - BECAUSE EOS IS SENT FROM MP4READER WHICH COMES TO DECODER AND THE FOLLOWING PROCESS IS NOT REQUIRED IN NVR. 
 	
-	auto frame = frame_sp(new EmptyFrame());
-	mDetail->compute(frame->data(), frame->size(), frame->timestamp);
-	LOG_ERROR << "processes sos " ;
-	mShouldTriggerSOS = true;
+	// auto frame = frame_sp(new EmptyFrame());
+	// mDetail->compute(frame->data(), frame->size(), frame->timestamp);
+	// LOG_ERROR << "processes sos " ;
+	// mShouldTriggerSOS = true;
 	return true;
 }
 

--- a/base/src/H264Decoder.cpp
+++ b/base/src/H264Decoder.cpp
@@ -733,12 +733,10 @@ bool H264Decoder::shouldTriggerSOS()
 
 bool H264Decoder::processEOS(string& pinId)
 {
-	//THIS HAS BEEN COMMENTED IN NVR - BECAUSE EOS IS SENT FROM MP4READER WHICH COMES TO DECODER AND THE FOLLOWING PROCESS IS NOT REQUIRED IN NVR. 
-	
-	// auto frame = frame_sp(new EmptyFrame());
-	// mDetail->compute(frame->data(), frame->size(), frame->timestamp);
-	// LOG_ERROR << "processes sos " ;
-	// mShouldTriggerSOS = true;
+	auto frame = frame_sp(new EmptyFrame());
+	mDetail->compute(frame->data(), frame->size(), frame->timestamp);
+	LOG_ERROR << "processes sos " ;
+	mShouldTriggerSOS = true;
 	return true;
 }
 

--- a/base/src/H264DecoderNvCodecHelper.cpp
+++ b/base/src/H264DecoderNvCodecHelper.cpp
@@ -562,6 +562,14 @@ NvDecoder::~NvDecoder() {
 			delete[] pFrame;
 		}
 	}
+
+	if(m_cuContext)
+	{
+		if (m_pMutex) m_pMutex->lock();
+		cuCtxDestroy(m_cuContext);
+		if (m_pMutex) m_pMutex->unlock();
+	}
+	
 	STOP_TIMER("Session Deinitialization Time: ");
 }
 

--- a/base/src/H264DecoderNvCodecHelper.cpp
+++ b/base/src/H264DecoderNvCodecHelper.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include <iostream>
 #include <algorithm>
 #include <chrono>

--- a/base/src/H264EncoderNVCodecHelper.cpp
+++ b/base/src/H264EncoderNVCodecHelper.cpp
@@ -603,7 +603,7 @@ private:
 			LOG_INFO << "Allocated <" << bufferLength << "> outputbitstreams to the encoder buffer.";
 			m_nvcodecResources->m_nFreeOutputBitstreams += bufferLength;
 		}
-		else
+		else if(!m_nvcodecResources->m_nFreeOutputBitstreams)
 		{
 			LOG_INFO << "waiting for free outputbitstream<> busy streams<" << m_nvcodecResources->m_nBusyOutputBitstreams << ">";
 		}

--- a/base/src/H264Utils.cpp
+++ b/base/src/H264Utils.cpp
@@ -111,4 +111,6 @@ H264Utils::H264_NAL_TYPE H264Utils::getNalTypeAfterSpsPps(void* frameData, size_
 			}
 		}
 	}
+
+	return typeFound;
 }

--- a/base/src/NvTransform.cpp
+++ b/base/src/NvTransform.cpp
@@ -259,7 +259,6 @@ void NvTransform::setMetadata(framemetadata_sp &metadata)
 
 bool NvTransform::processEOS(string &pinId)
 {
-	//THE FOLLOWING LINE IS COMMENTED FOR SPECIFIC USE IN NVR - MP4READER PASSING EOS WAS COMING HERE AND CAUSING EOS WHICH IS NOT REQUIRED FOR NVR
 	mDetail->outputMetadata.reset();
 	return true;
 }

--- a/base/src/NvTransform.cpp
+++ b/base/src/NvTransform.cpp
@@ -260,6 +260,6 @@ void NvTransform::setMetadata(framemetadata_sp &metadata)
 bool NvTransform::processEOS(string &pinId)
 {
 	//THE FOLLOWING LINE IS COMMENTED FOR SPECIFIC USE IN NVR - MP4READER PASSING EOS WAS COMING HERE AND CAUSING EOS WHICH IS NOT REQUIRED FOR NVR
-	// mDetail->outputMetadata.reset();
+	mDetail->outputMetadata.reset();
 	return true;
 }

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -232,6 +232,11 @@ void PipeLine::stop()
 			i->get()->stop();
 		}
 	}
+
+	if ((modules[0]->controlModule) != nullptr)
+	{
+		modules[0]->controlModule->stop();
+	}
 }
 
 void PipeLine::wait_for_all(bool ignoreStatus)
@@ -242,15 +247,15 @@ void PipeLine::wait_for_all(bool ignoreStatus)
 		return;
 	}
 
-	for (auto i = modules.begin(); i != modules.end(); i++)
-	{
-		Module& m = *(i->get());
-		m.myThread.join();
-	}
-
 	if ((modules[0]->controlModule) != nullptr)
 	{
 		Module& m = *(modules[0]->controlModule);
+		m.myThread.join();
+	}
+
+	for (auto i = modules.begin(); i != modules.end(); i++)
+	{
+		Module& m = *(i->get());
 		m.myThread.join();
 	}
 }
@@ -264,12 +269,6 @@ void PipeLine::interrupt_wait_for_all()
 		return;
 	}
 
-	for (auto i = modules.begin(); i != modules.end(); i++)
-	{
-		Module& m = *(i->get());
-		m.myThread.interrupt();
-	}
-
 	if ((modules[0]->controlModule) != nullptr)
 	{
 		Module& m = *(modules[0]->controlModule);
@@ -279,12 +278,18 @@ void PipeLine::interrupt_wait_for_all()
 	for (auto i = modules.begin(); i != modules.end(); i++)
 	{
 		Module& m = *(i->get());
+		m.myThread.interrupt();
+	}
+
+	if ((modules[0]->controlModule) != nullptr)
+	{
+		Module& m = *(modules[0]->controlModule);
 		m.myThread.join();
 	}
 
-	if ((modules[0]->controlModule) != nullptr)
+	for (auto i = modules.begin(); i != modules.end(); i++)
 	{
-		Module& m = *(modules[0]->controlModule);
+		Module& m = *(i->get());
 		m.myThread.join();
 	}
 

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -247,6 +247,12 @@ void PipeLine::wait_for_all(bool ignoreStatus)
 		Module& m = *(i->get());
 		m.myThread.join();
 	}
+
+	if ((modules[0]->controlModule) != nullptr)
+	{
+		Module& m = *(modules[0]->controlModule);
+		m.myThread.join();
+	}
 }
 
 
@@ -264,11 +270,24 @@ void PipeLine::interrup_wait_for_all()
 		m.myThread.interrupt();
 	}
 
+	if ((modules[0]->controlModule) != nullptr)
+	{
+		Module& m = *(modules[0]->controlModule);
+		m.myThread.interrupt();
+	}
+
 	for (auto i = modules.begin(); i != modules.end(); i++)
 	{
 		Module& m = *(i->get());
 		m.myThread.join();
 	}
+
+	if ((modules[0]->controlModule) != nullptr)
+	{
+		Module& m = *(modules[0]->controlModule);
+		m.myThread.join();
+	}
+
 	myStatus = PL_STOPPED;
 }
 

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -161,7 +161,7 @@ void PipeLine::run_all_threaded()
 	}
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule->get());
+		Module& m = *(modules[0]->controlModule);
 		m.myThread = boost::thread(ref(m));
 	}
 	mPlay = true;
@@ -250,7 +250,7 @@ void PipeLine::wait_for_all(bool ignoreStatus)
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule->get());
+		Module& m = *(modules[0]->controlModule);
 		m.myThread.join();
 	}
 }
@@ -272,7 +272,7 @@ void PipeLine::interrupt_wait_for_all()
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule->get());
+		Module& m = *(modules[0]->controlModule);
 		m.myThread.interrupt();
 	}
 
@@ -284,7 +284,7 @@ void PipeLine::interrupt_wait_for_all()
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule->get());
+		Module& m = *(modules[0]->controlModule);
 		m.myThread.join();
 	}
 

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -37,7 +37,6 @@ bool PipeLine::addControlModule(boost::shared_ptr<AbsControlModule> cModule)
 	for (int i = 0; i < modules.size(); i++)
 	{
 		modules[i]->addControlModule(cModule);
-		cModule->pipelineModules.push_back(modules[i]);
 	}
 	return true;
 }

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -163,6 +163,7 @@ void PipeLine::run_all_threaded()
 	{
 		Module& m = *(modules[0]->controlModule);
 		m.myThread = boost::thread(ref(m));
+		Utils::setModuleThreadName(m.myThread, m.getId());
 	}
 	mPlay = true;
 }

--- a/base/src/PipeLine.cpp
+++ b/base/src/PipeLine.cpp
@@ -161,7 +161,7 @@ void PipeLine::run_all_threaded()
 	}
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule);
+		Module& m = *(modules[0]->controlModule->get());
 		m.myThread = boost::thread(ref(m));
 	}
 	mPlay = true;
@@ -250,13 +250,13 @@ void PipeLine::wait_for_all(bool ignoreStatus)
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule);
+		Module& m = *(modules[0]->controlModule->get());
 		m.myThread.join();
 	}
 }
 
 
-void PipeLine::interrup_wait_for_all()
+void PipeLine::interrupt_wait_for_all()
 {
 	if (myStatus > PL_STOPPING)
 	{
@@ -272,7 +272,7 @@ void PipeLine::interrup_wait_for_all()
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule);
+		Module& m = *(modules[0]->controlModule->get());
 		m.myThread.interrupt();
 	}
 
@@ -284,7 +284,7 @@ void PipeLine::interrup_wait_for_all()
 
 	if ((modules[0]->controlModule) != nullptr)
 	{
-		Module& m = *(modules[0]->controlModule);
+		Module& m = *(modules[0]->controlModule->get());
 		m.myThread.join();
 	}
 

--- a/base/vcpkg.json
+++ b/base/vcpkg.json
@@ -86,14 +86,6 @@
       "platform": "!arm64"
     },
     {
-      "name": "re",
-      "platform": "!windows"
-    },
-    {
-      "name": "baresip",
-      "platform": "!windows"
-    },
-    {
       "name": "libmp4"
     }
   ]


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**

### Summary

1. **Remove Baresip and Libre dependencies**
   - Completely removed Baresip and Libre from the project.

2. **Revert changes in H264Decoder and NvTransform (specific to NVR)**
   - Reverted all modifications made for NVR in the `H264Decoder` and `NvTransform` components.
   - Restored the previous, non-NVR-specific implementations.

3. **Fix memory leak in nvcodec decoder**
   - Identified and resolved a memory leak in the `nvcodec` decoder.
   - Cuda Context was not being released when destructor is called.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
