### PR TITLE
Fixing the FileReaderModule issue

### DIFF
--- a/base/include/FileSequenceDriver.h
+++ b/base/include/FileSequenceDriver.h
@@ -26,6 +26,7 @@ public:
 
     bool Read(uint8_t*& dataToRead, size_t& dataSize, uint64_t& index);
 	bool ReadP(BufferMaker& buffMaker, uint64_t& index);
+    bool ReadP(BufferMaker& buffMaker, uint64_t& index, size_t& userMetadataSize);
     bool Write(const uint8_t* dataToWrite, size_t dataSize);
 	    
     void SetReadLoop(bool readLoop);

--- a/base/src/FileReaderModule.cpp
+++ b/base/src/FileReaderModule.cpp
@@ -69,12 +69,29 @@ bool FileReaderModule::produce()
 	}
 	
 	FFBufferMaker buffMaker(*this);
-		
 	uint64_t fIndex2 = 0;
-	if (!mDriver->ReadP(buffMaker, fIndex2))
-	{
-		return false;
-	}
+
+	auto metadata = getOutputFrameFactory().begin()->second->getFrameMetadata();
+	size_t userMetadataSize = metadata->getDataSize();
+
+	// Handle cases where dataSize is not set
+    if (!metadata->isSet() || userMetadataSize == NOT_SET_NUM)
+    {
+        // Use file size as buffer size
+        if (!mDriver->ReadP(buffMaker, fIndex2))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        // Use metadata's dataSize
+        if (!mDriver->ReadP(buffMaker, fIndex2, userMetadataSize))
+        {
+            return false;
+        }
+    }
+
 	auto frame = buffMaker.getFrame();
 	frame->fIndex2 = fIndex2;
 	

--- a/base/test/filereadermodule_tests.cpp
+++ b/base/test/filereadermodule_tests.cpp
@@ -14,6 +14,49 @@
 
 BOOST_AUTO_TEST_SUITE(filereadermodule_tests)
 
+BOOST_AUTO_TEST_CASE(metadatasize)
+{
+    auto fileReader = boost::shared_ptr<FileReaderModule>(new FileReaderModule(FileReaderModuleProps("./data/RGB_320x180.raw")));
+
+    // Custom RawImageMetadata configurations
+    int width = 500;
+    int height = 500;
+    int channels = 3;
+    int type = CV_8UC3;
+    size_t alignLength = 1;
+    int depth = CV_8U;
+    auto rawImageMetadata = framemetadata_sp(new RawImageMetadata(width, height, ImageMetadata::RGB, type, alignLength, depth, FrameMetadata::HOST, true));
+	auto expectedDataSize = width * height * channels;
+
+    auto pinId = fileReader->addOutputPin(rawImageMetadata);
+
+    auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+    fileReader->setNext(sink);
+        
+    BOOST_TEST(fileReader->init());
+    BOOST_TEST(sink->init());
+
+    fileReader->play(true);
+    
+    fileReader->step();
+    auto frames = sink->pop();
+    
+	BOOST_TEST((frames.find(pinId) != frames.end()));
+    
+	auto frame = frames[pinId];
+
+    BOOST_TEST(frame->size() == expectedDataSize);
+
+    // Print the size of the frame and the metadata size
+    std::cout << "Frame size: " << frame->size() << std::endl;
+    std::cout << "Metadata size: " << rawImageMetadata->getDataSize() << std::endl;
+	std::cout << "FrameType: " << rawImageMetadata->getFrameType() << std::endl;
+    std::cout << "MemType: " << rawImageMetadata->getMemType() << std::endl;
+
+    fileReader->term();
+    sink->term();
+}
+
 BOOST_AUTO_TEST_CASE(basic)
 {
 	auto fileReader = boost::shared_ptr<FileReaderModule>(new FileReaderModule(FileReaderModuleProps("./data/filenamestrategydata/?.txt")));


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[374](https://github.com/Apra-Labs/ApraPipes/issues/374)

**Description**

1. The FileReaderModule was not respecting the data size specified in the frame metadata when creating frames. Instead, it used the file size directly, which caused issues when additional buffer space was required.
2. Added a read function to use the metadata's size when creating frames. If the metadata's size is larger than the file size, the frame buffer is resized accordingly.
3. Updated FileReaderModule to handle cases where the metadata's size is not explicitly set. In such cases, the file size is used as the buffer size.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
