### PR TITLE
Force build scripts on linux to install cmake version 3.29.6

### DIFF
--- a/build_scripts/build_dependencies_jetson_cuda.sh
+++ b/build_scripts/build_dependencies_jetson_cuda.sh
@@ -20,10 +20,11 @@ if [ "${#missing_dependencies[@]}" -gt 0 ]; then
 fi
 
 # Install Cmake if not present
-if ! cmake --version; then
+if ! cmake --version &>/dev/null; then
   echo "CMake is not installed. Installing CMake..."
-  snap install cmake --classic
+  pip3 install cmake==3.29.6
 fi
+
 
 if [ ! -d "/usr/local/cuda/include" ] || [ ! -d "/usr/local/cuda/lib64" ]; then
   echo "ERROR: CUDA Toolkit is not properly installed. Please install CUDA Toolkit."

--- a/build_scripts/build_dependencies_linux_cuda.sh
+++ b/build_scripts/build_dependencies_linux_cuda.sh
@@ -33,7 +33,7 @@ fi
 # Install Cmake if not present
 if ! cmake --version &>/dev/null; then
   echo "CMake is not installed. Installing CMake..."
-  pip3 install cmake --upgrade
+  pip3 install cmake==3.29.6
 fi
 
 # Install jq if not present

--- a/build_scripts/build_dependencies_linux_no_cuda.sh
+++ b/build_scripts/build_dependencies_linux_no_cuda.sh
@@ -32,7 +32,7 @@ fi
 # Install Cmake if not present
 if ! cmake --version &>/dev/null; then
   echo "CMake is not installed. Installing CMake..."
-  pip3 install cmake --upgrade
+  pip3 install cmake==3.29.6
 fi
 
 # Install jq if not present


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**

pip installs the latest version of cmake (current version ~4.0.0). This is incompatible with some of the packages that are listed in vcpkg.json
This change will install version 3.29.6 which is compatible with the packages.

**Alternative(s) considered**

Have you considered any alternatives? And if so, why have you chosen the approach in this PR?

**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
