### PR TITLE
fix: make FrameContainerQueue::pop() blocking to prevent CPU spinning

### DIFF
--- a/base/include/FrameContainerQueue.h
+++ b/base/include/FrameContainerQueue.h
@@ -55,15 +55,9 @@ public:
 	}
 	frame_container pop() {
 		if (mAdaptee.get() != nullptr)
-		{
-			frame_container ret = mAdaptee->try_pop();
-			if (ret.size() == 0)
-			{
-				return on_failed_pop();
-			}
-			else {
-				return on_pop_success(ret);
-			}
+	{
+			frame_container ret = mAdaptee->pop();
+			return on_pop_success(ret);
 		}
 		return frame_container();
 	}


### PR DESCRIPTION
**IMPORTANT: All PRs must be linked to an issue (except for extremely trivial and straightforward changes).**

Fixes #[Issue]

**Description**

Refactord Pop function to block the thread, when no frames are their in the queue
  
**Type**

Type Choose one: (Bug fix | Feature | Documentation | Testing | Other)

**Screenshots (if applicable)**

**Checklist**

- [x] I have read the [Contribution Guidelines](https://github.com/Apra-Labs/ApraPipes/wiki/Contribution-Guidelines)
- [x] I have written Unit Tests
- [x] I have discussed my proposed solution with code owners in the linked issue(s) and we have agreed upon the general approach
