### PR TITLE
Propagate seek failure near live edge to control module to trigger seek retries

### DIFF
--- a/base/include/ArchiveSpaceManager.h
+++ b/base/include/ArchiveSpaceManager.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "AIPExceptions.h"
 #include "Module.h"
+#include <functional>
+
+typedef std::function<void(const std::string&)> DeletedDirCallback;
 
 class ArchiveSpaceManagerProps : public ModuleProps {
 public:
@@ -11,18 +14,6 @@ public:
     pathToWatch = _pathToWatch;
     samplingFreq = _samplingFreq;
     fps = 0.001;
-
-    // auto totalSpace = boost::filesystem::space(pathToWatch);
-    // if ((lowerWaterMark > upperWaterMark) || (upperWaterMark >
-    // totalSpace.capacity))
-    // {
-    // 	LOG_ERROR << "Please enter correct properties!";
-    // 	std::string errorMsg = "Incorrect properties set for Archive Manager.
-    // TotalDiskCapacity <" + std::to_string(totalSpace.capacity) +
-    // ">lowerWaterMark<" + std::to_string(lowerWaterMark) + "> UpperWaterMark<"
-    // + std::to_string(upperWaterMark) + ">"; 	throw AIPException(AIP_FATAL,
-    // errorMsg);
-    // }
   }
 
   ArchiveSpaceManagerProps(uint64_t maxSizeAllowed, string _pathToWatch,
@@ -32,18 +23,6 @@ public:
     pathToWatch = _pathToWatch;
     samplingFreq = _samplingFreq;
     fps = 0.001;
-
-    // auto totalSpace = boost::filesystem::space(pathToWatch);
-    // if ((lowerWaterMark > upperWaterMark) || (upperWaterMark >
-    // totalSpace.capacity))
-    // {
-    // 	LOG_ERROR << "Please enter correct properties!";
-    // 	std::string errorMsg = "Incorrect properties set for Archive Manager.
-    // TotalDiskCapacity <" + std::to_string(totalSpace.capacity) +
-    // ">lowerWaterMark<" + std::to_string(lowerWaterMark) + "> UpperWaterMark<"
-    // + std::to_string(upperWaterMark) + ">"; 	throw AIPException(AIP_FATAL,
-    // errorMsg);
-    // }
   }
 
   uint64_t lowerWaterMark; // Lower disk space
@@ -79,6 +58,7 @@ public:
   void setProps(ArchiveSpaceManagerProps &props);
   ArchiveSpaceManagerProps getProps();
 
+  void registerDeletedDirCallback(DeletedDirCallback callback);
 protected:
   bool produce();
   bool validateInputPins();
@@ -90,5 +70,6 @@ protected:
 private:
   class Detail;
   boost::shared_ptr<Detail> mDetail;
+  DeletedDirCallback mDeletedDirCallback;
   bool checkDirectory = true;
 };

--- a/base/include/Command.h
+++ b/base/include/Command.h
@@ -24,7 +24,8 @@ public:
     SendMMQTimestamps,
     SendLastGTKGLRenderTS,
     DecoderPlaybackSpeed,
-    Mp4FileClose
+    Mp4FileClose,
+    Mp4ReaderPlaybackSpeed
   };
 
   Command() { type = CommandType::None; }
@@ -323,5 +324,41 @@ private:
 		ar& boost::serialization::base_object<Command>(*this);
 		ar& playbackFps;
 		ar& playbackSpeed;
+	}
+};
+
+
+class Mp4ReaderPlaybackSpeedCommand : public Command
+{
+public:
+	Mp4ReaderPlaybackSpeedCommand() : Command(CommandType::Mp4ReaderPlaybackSpeed)
+	{
+		playbackSpeed = 1.0f;
+		direction = true;
+	}
+
+	Mp4ReaderPlaybackSpeedCommand(float _playbackSpeed, bool _direction = true)
+		: Command(CommandType::Mp4ReaderPlaybackSpeed)
+	{
+		playbackSpeed = _playbackSpeed;
+		direction = _direction;
+	}
+
+	size_t getSerializeSize()
+	{
+		return Command::getSerializeSize() + sizeof(playbackSpeed) + sizeof(direction);
+	}
+
+	float playbackSpeed;
+	bool direction; // fwd = true, bwd = false
+
+private:
+	friend class boost::serialization::access;
+	template<class Archive>
+	void serialize(Archive& ar, const unsigned int /* file_version */)
+	{
+		ar& boost::serialization::base_object<Command>(*this);
+		ar& playbackSpeed;
+		ar& direction;
 	}
 };

--- a/base/include/Mp4ReaderSource.h
+++ b/base/include/Mp4ReaderSource.h
@@ -45,7 +45,31 @@ public:
 				"> reInitInterval <" + std::to_string(reInitInterval) + "> parseFS <" + std::to_string(_parseFS) + ">";
 			throw AIPException(AIP_FATAL, errMsg);
 		}
-		auto canonicalVideoPath = boost::filesystem::canonical(_videoPath);
+		// Resolve videoPath robustly for both in-tree runs and out-of-tree build dirs.
+		// 1) Try to canonicalize as given (relative to current working directory).
+		// 2) If that fails (e.g. running from _build/_debugbuild with ./data/...),
+		//    try resolving relative to the parent directory (typically project root).
+		boost::filesystem::path canonicalVideoPath;
+		try
+		{
+			canonicalVideoPath = boost::filesystem::canonical(_videoPath);
+		}
+		catch (const boost::filesystem::filesystem_error &)
+		{
+			try
+			{
+				auto cwd = boost::filesystem::current_path();
+				auto projectRoot = cwd.parent_path();
+				canonicalVideoPath = boost::filesystem::canonical(projectRoot / _videoPath);
+			}
+			catch (const boost::filesystem::filesystem_error &)
+			{
+				auto errMsg = "Video File name not in proper format.Check the filename sent as props. "
+					"If you want to read a file with custom name instead, please disable parseFS flag.";
+				throw AIPException(AIP_FATAL, errMsg);
+			}
+		}
+
 		videoPath = canonicalVideoPath.string();
 		parseFS = _parseFS;
 		bFramesEnabled = _bFramesEnabled;

--- a/base/include/Mp4ReaderSource.h
+++ b/base/include/Mp4ReaderSource.h
@@ -14,7 +14,7 @@ public:
 
 	}
 
-	Mp4ReaderSourceProps(std::string _videoPath, bool _parseFS, uint16_t _reInitInterval, bool _direction, bool _readLoop, bool _giveLiveTS, int _parseFSTimeoutDuration = 15, bool _bFramesEnabled = false) : ModuleProps()
+	Mp4ReaderSourceProps(std::string _videoPath, bool _parseFS, uint16_t _reInitInterval, bool _direction, bool _readLoop, bool _giveLiveTS, int _parseFSTimeoutDuration = 15, bool _bFramesEnabled = false, float _playbackSpeed = 1.0f, uint64_t _startTimestamp = 0) : ModuleProps()
 	{
 		/* About props:
 			- videoPath - Path of a video from where the reading will start.
@@ -23,11 +23,19 @@ public:
 			- parseFS - Read the NVR format till infinity, if true. Else we read only one file.
 			- readLoop - Read a single video in loop. It can not be used in conjuction with live mode (reInitInterval > 0) or NVR mode (parseFS = true) mode.
 			- giveLiveTS - If enabled, gives live timestamps instead of recorded timestamps in the video files.
+			- playbackSpeed - Initial playback speed (0.25x to 32x). Can be changed dynamically via changePlaybackSpeed().
+			- startTimestamp - Optional hint timestamp (in milliseconds) for where playback will start. Used to optimize initial cache building in parseFS mode.
 		*/
 
 		if (reInitInterval < 0)
 		{
 			auto errMsg = "incorrect prop reInitInterval <" + std::to_string(reInitInterval) + ">";
+			throw AIPException(AIP_FATAL, errMsg);
+		}
+
+		if (_playbackSpeed <= 0.0f)
+		{
+			auto errMsg = "playbackSpeed must be greater than 0. Provided: <" + std::to_string(_playbackSpeed) + ">";
 			throw AIPException(AIP_FATAL, errMsg);
 		}
 
@@ -42,6 +50,8 @@ public:
 		parseFS = _parseFS;
 		bFramesEnabled = _bFramesEnabled;
 		direction = _direction;
+		playbackSpeed = _playbackSpeed;
+		startTimestamp = _startTimestamp;
 		giveLiveTS = _giveLiveTS;
 		if (_reInitInterval < 0)
 		{
@@ -70,7 +80,7 @@ public:
 
 	size_t getSerializeSize()
 	{
-		return ModuleProps::getSerializeSize() + sizeof(videoPath) + sizeof(parseFS) + sizeof(skipDir) + sizeof(direction) + sizeof(parseFSTimeoutDuration) + sizeof(biggerFrameSize) + sizeof(biggerMetadataFrameSize) + sizeof(bFramesEnabled) + sizeof(forceFPS);
+		return ModuleProps::getSerializeSize() + sizeof(videoPath) + sizeof(parseFS) + sizeof(skipDir) + sizeof(direction) + sizeof(parseFSTimeoutDuration) + sizeof(biggerFrameSize) + sizeof(biggerMetadataFrameSize) + sizeof(bFramesEnabled) + sizeof(forceFPS) + sizeof(playbackSpeed) + sizeof(startTimestamp);
 	}
 
 	std::string skipDir = "./data/Mp4_videos";
@@ -85,6 +95,8 @@ public:
 	bool readLoop = false;
 	bool giveLiveTS = false;
 	bool forceFPS = false;
+	float playbackSpeed = 1.0f;
+	uint64_t startTimestamp = 0;
 private:
 	friend class boost::serialization::access;
 
@@ -103,6 +115,8 @@ private:
 		ar& readLoop;
 		ar& giveLiveTS;
 		ar& forceFPS;
+		ar& playbackSpeed;
+		ar& startTimestamp;
 	}
 };
 
@@ -119,6 +133,7 @@ public:
 	void setImageMetadata(std::string& pinId, framemetadata_sp& metadata);
 	std::string addOutPutPin(framemetadata_sp& metadata);
 	bool changePlayback(float speed, bool direction);
+	bool changePlaybackSpeed(float speed, bool direction = true);
 	bool getVideoRangeFromCache(std::string videoPath, uint64_t& start_ts, uint64_t& end_ts);
 	bool randomSeek(uint64_t skipTS, bool forceReopen = false);
 	bool refreshCache();

--- a/base/src/ArchiveSpaceManager.cpp
+++ b/base/src/ArchiveSpaceManager.cpp
@@ -92,31 +92,32 @@ public:
     return _cam;
   };
 
-boost::filesystem::path getOldestHourDirByName(const boost::filesystem::path& cameraDir)
-{
-    boost::filesystem::path oldestDay;
-    for (const auto& dayEntry : boost::filesystem::directory_iterator(cameraDir))
+  boost::filesystem::path getOldestHourDirByName(const boost::filesystem::path& cameraDir)
+  {
+  boost::filesystem::path oldestDay;
+  for (const auto& dayEntry : boost::filesystem::directory_iterator(cameraDir))
+  {
+  LOG_INFO<<"dayEntry path"<<dayEntry.path();
+  if (!boost::filesystem::is_directory(dayEntry)) continue;
+    if (oldestDay.empty() || dayEntry.path().filename() < oldestDay.filename())
     {
-        LOG_INFO<<"dayEntry path"<<dayEntry.path();
-        if (!boost::filesystem::is_directory(dayEntry)) continue;
-        if (oldestDay.empty() || dayEntry.path().filename() < oldestDay.filename())
-            oldestDay = dayEntry.path();
+    oldestDay = dayEntry.path();
     }
+  }
 
-     boost::filesystem::path oldestHour;
+  boost::filesystem::path oldestHour;
     for (const auto& hourEntry : boost::filesystem::directory_iterator(oldestDay))
     {
-        if (!boost::filesystem::is_directory(hourEntry)) continue;
-        if (oldestHour.empty() || hourEntry.path().filename() < oldestHour.filename())
-            LOG_INFO<<"hourEntry path"<<hourEntry.path();
-            oldestHour = hourEntry.path();
+      if (!boost::filesystem::is_directory(hourEntry)) continue;
+      if (oldestHour.empty() || hourEntry.path().filename() < oldestHour.filename())
+      { 
+        LOG_INFO<<"hourEntry path"<<hourEntry.path();
+        oldestHour = hourEntry.path();
+      }
     }
-    return oldestHour;
-}
-
-
- 
-
+  return oldestHour;
+  }
+  
    void manageDirectory()
   {
     auto comparator = [](const std::pair<boost::filesystem::path, uint64_t> &a,

--- a/base/src/ArchiveSpaceManager.cpp
+++ b/base/src/ArchiveSpaceManager.cpp
@@ -113,6 +113,11 @@ public:
     }
   }
 
+  if (oldestDay.empty())
+  {
+    return {};
+  }
+
   boost::filesystem::path oldestHour;
     for (const auto& hourEntry : boost::filesystem::directory_iterator(oldestDay))
     {
@@ -167,6 +172,19 @@ public:
       for (const auto &camFolder :
            boost::filesystem::directory_iterator(mProps.pathToWatch))
       {
+        if (boost::filesystem::is_empty(camFolder))
+        {
+        LOG_INFO << "Camera folder is empty, deleting: " << camFolder.path().string();
+          try
+          {
+          boost::filesystem::remove_all(camFolder);
+          }
+        catch (const std::exception& e)
+          {
+            LOG_ERROR << "Could not delete empty camera folder: " << e.what();
+          }
+          continue; // skip to next camFolder
+        }
         
         boost::filesystem::path oldHrDir = getOldestHourDirByName(camFolder);
 

--- a/base/src/ArchiveSpaceManager.cpp
+++ b/base/src/ArchiveSpaceManager.cpp
@@ -8,14 +8,22 @@
 class ArchiveSpaceManager::Detail
 {
 public:
-  Detail(ArchiveSpaceManagerProps &_props) : mProps(_props) {}
+  Detail(ArchiveSpaceManagerProps &_props) : mProps(_props), mParent(nullptr), mDeletedDirCallback(nullptr) {}
 
   ~Detail() {}
 
+  void setParent(ArchiveSpaceManager* parent) { mParent = parent; }
+
   void setProps(ArchiveSpaceManagerProps _props) { mProps = _props; }
 
- uint64_t estimateDirectorySize(boost::filesystem::path _dir)
-{
+  void registerCallback(DeletedDirCallback callback)
+  {
+    mDeletedDirCallback = callback;
+    LOG_INFO << "Callback registered in Detail class";
+  }
+
+  uint64_t estimateDirectorySize(boost::filesystem::path _dir)
+  {
     uint64_t dirSize = 0;
     int sample = 0;
     int inCount = 0;
@@ -34,7 +42,7 @@ public:
         {
             if (boost::filesystem::is_regular_file(entry))
             {
-                if (countFreq % mProps.samplingFreq == 0)
+                if (mProps.samplingFreq > 0 && countFreq % mProps.samplingFreq == 0)
                 {
                     sample = (rand() % mProps.samplingFreq);
                     inCount = 0;
@@ -117,6 +125,33 @@ public:
     }
   return oldestHour;
   }
+
+  void invokeDeleteCallback(const std::string& deletedDir)
+  {
+    LOG_INFO << "========================================";
+    LOG_INFO << "invokeDeleteCallback called for: " << deletedDir;
+    LOG_INFO << "mParent is: " << (mParent ? "NOT NULL" : "NULL");
+    LOG_INFO << "mDeletedDirCallback is set: " << (mDeletedDirCallback ? "YES" : "NO");
+    LOG_INFO << "========================================";
+    
+    if (mDeletedDirCallback)
+    {
+      try
+      {
+        LOG_INFO << "Invoking callback for deleted directory: " << deletedDir;
+        mDeletedDirCallback(deletedDir);
+        LOG_INFO << "Callback invoked successfully";
+      }
+      catch (const std::exception& e)
+      {
+        LOG_ERROR << "Exception in callback: " << e.what();
+      }
+    }
+    else
+    {
+      LOG_WARNING << "Callback not set or mParent is null - callback not invoked";
+    }
+  }
   
    void manageDirectory()
   {
@@ -127,6 +162,8 @@ public:
     };
     while (archiveSize > mProps.lowerWaterMark)
     {
+      foldVector.clear(); // Clear at the beginning of each iteration
+      
       for (const auto &camFolder :
            boost::filesystem::directory_iterator(mProps.pathToWatch))
       {
@@ -171,38 +208,49 @@ public:
 
       uint64_t tempSize = 0;
       boost::filesystem::path delDir = foldVector[0].first;
+      std::string deletedDirPath = delDir.string(); // Store path before deletion
 
-        if (!boost::filesystem::exists(delDir) || !boost::filesystem::is_directory(delDir))
-       {
-          LOG_ERROR << "Directory to delete does not exist or is not a directory: " << delDir.string();
-          foldVector.clear();
-          continue;
-       }
-       BOOST_LOG_TRIVIAL(info) << "Deleting folder : " << delDir.string();
-       tempSize = estimateDirectorySize(delDir);
-       archiveSize = archiveSize - tempSize;
-       LOG_INFO<<"archive size after deleting"<<archiveSize;
+      if (!boost::filesystem::exists(delDir) || !boost::filesystem::is_directory(delDir))
+      {
+        LOG_ERROR << "Directory to delete does not exist or is not a directory: " << delDir.string();
+        foldVector.clear();
+        continue;
+      }
+      BOOST_LOG_TRIVIAL(info) << "Deleting folder : " << delDir.string();
+      tempSize = estimateDirectorySize(delDir);
+      archiveSize = archiveSize - tempSize;
+      LOG_INFO<<"archive size after deleting"<<archiveSize;
       try
       {
         boost::filesystem::remove_all(delDir);
+        
+        invokeDeleteCallback(deletedDirPath);
+        
+        // Try to delete parent directory if empty
         boost::filesystem::path parentDir = delDir.parent_path();
-         if (boost::filesystem::exists(parentDir) && boost::filesystem::is_directory(parentDir) && boost::filesystem::is_empty(parentDir))
+        if (boost::filesystem::exists(parentDir) && 
+            boost::filesystem::is_directory(parentDir) && 
+            boost::filesystem::is_empty(parentDir))
         {
-            BOOST_LOG_TRIVIAL(info) << "Deleting parent directory : " << parentDir.string();
-            try {
-                boost::filesystem::remove_all(parentDir);
-            } catch (const std::exception& e) {
-                LOG_ERROR << "Could not delete parent directory: " << e.what();
-            }
+          BOOST_LOG_TRIVIAL(info) << "Deleting parent directory : " << parentDir.string();
+          try
+          {
+            boost::filesystem::remove_all(parentDir);
+            // Invoke callback for parent directory deletion as well
+            invokeDeleteCallback(parentDir.string());
+          }
+          catch (const std::exception& e)
+          {
+            LOG_ERROR << "Could not delete parent directory: " << e.what();
+          }
         }
       }
-      catch (...)
+      catch (const std::exception& e)
       {
-        LOG_ERROR << "Could not delete directory!..";
+        LOG_ERROR << "Could not delete directory: " << e.what();
       }
-      foldVector.clear();
-      LOG_INFO<<"clearing the folder vectors";
-   
+
+      LOG_INFO<<"Cleared the folder vectors";
     }
   }
   uint64_t diskOperation()
@@ -225,12 +273,15 @@ public:
   ArchiveSpaceManagerProps mProps;
   uint64_t archiveSize = 0;
   std::vector<std::pair<boost::filesystem::path, uint64_t>> foldVector;
+  ArchiveSpaceManager* mParent;
+  std::function<void(const std::string&)> mDeletedDirCallback;  // FIX 4: Store callback in Detail
 };
 
 ArchiveSpaceManager::ArchiveSpaceManager(ArchiveSpaceManagerProps _props)
     : Module(SOURCE, "ArchiveSpaceManager", _props)
 {
   mDetail.reset(new Detail(_props));
+  mDetail->setParent(this);
 }
 
 bool ArchiveSpaceManager::validateInputPins() { return true; }
@@ -273,6 +324,20 @@ bool ArchiveSpaceManager::handlePropsChange(frame_sp &frame)
   auto ret = Module::handlePropsChange(frame, props);
   mDetail->setProps(props);
   return ret;
+}
+
+void ArchiveSpaceManager::registerDeletedDirCallback(DeletedDirCallback callback)
+{
+  LOG_INFO << "ArchiveSpaceManager::registerDeletedDirCallback called";
+  if (mDetail)
+  {
+    mDetail->registerCallback(callback);
+    LOG_INFO << "Callback registered successfully in ArchiveSpaceManager";
+  }
+  else
+  {
+    LOG_ERROR << "mDetail is null - cannot register callback";
+  }
 }
 
 bool ArchiveSpaceManager::produce()

--- a/base/src/ArchiveSpaceManager.cpp
+++ b/base/src/ArchiveSpaceManager.cpp
@@ -14,54 +14,66 @@ public:
 
   void setProps(ArchiveSpaceManagerProps _props) { mProps = _props; }
 
-  uint64_t estimateDirectorySize(boost::filesystem::path _dir)
-  {
+ uint64_t estimateDirectorySize(boost::filesystem::path _dir)
+{
     uint64_t dirSize = 0;
     int sample = 0;
     int inCount = 0;
     int countFreq = 0;
     uint64_t tempSize = 0;
 
-    for (const auto &entry :
-         boost::filesystem::recursive_directory_iterator(_dir))
+    if (!boost::filesystem::exists(_dir) || !boost::filesystem::is_directory(_dir))
     {
-      if (boost::filesystem::is_regular_file(entry))
-      {
-        if (countFreq % mProps.samplingFreq == 0)
-        {
-          sample = (rand() % mProps.samplingFreq);
-          inCount = 0;
-        }
-
-        if (inCount == sample)
-        {
-          try
-          {
-            tempSize = boost::filesystem::file_size(entry);
-            dirSize += tempSize * mProps.samplingFreq;
-          }
-          catch (const std::exception &e)
-          {
-            LOG_INFO << "Failed to get file size for " << entry << ": "
-                      << e.what();
-          }
-        }
-
-        inCount++;
-        countFreq++;
-      }
+        LOG_ERROR << "Directory does not exist or is not a directory: " << _dir.string();
+        return 0;
     }
 
-    // Adjust for the remaining files if they are fewer than the sampling
-    // frequency
+    try
+    {
+        for (const auto &entry : boost::filesystem::recursive_directory_iterator(_dir))
+        {
+            if (boost::filesystem::is_regular_file(entry))
+            {
+                if (countFreq % mProps.samplingFreq == 0)
+                {
+                    sample = (rand() % mProps.samplingFreq);
+                    inCount = 0;
+                }
+
+                if (inCount == sample)
+                {
+                    try
+                    {
+                        tempSize = boost::filesystem::file_size(entry);
+                        dirSize += tempSize * mProps.samplingFreq;
+                    }
+                    catch (const std::exception &e)
+                    {
+                        LOG_INFO << "Failed to get file size for " << entry.path().string() << ": "
+                                 << e.what();
+                    }
+                }
+
+                inCount++;
+                countFreq++;
+            }
+        }
+    }
+    catch (const std::exception &e)
+    {
+        LOG_ERROR << "Failed to iterate directory " << _dir.string() << ": " << e.what();
+        return 0;
+    }
+
+    // Adjust for the remaining files if they are fewer than the sampling frequency
     if (inCount < mProps.samplingFreq && inCount > 0)
     {
       dirSize += tempSize * inCount;
     }
 
-    LOG_TRACE << "Total Directory Size: " << dirSize;
+    LOG_INFO << "Total Directory Size: " << dirSize;
     return dirSize;
-  }
+}
 
   boost::filesystem::path getOldestDirectory(boost::filesystem::path _cam)
   {
@@ -80,53 +92,125 @@ public:
     return _cam;
   };
 
-  void manageDirectory()
+boost::filesystem::path getOldestHourDirByName(const boost::filesystem::path& cameraDir)
+{
+    boost::filesystem::path oldestDay;
+    for (const auto& dayEntry : boost::filesystem::directory_iterator(cameraDir))
+    {
+        LOG_INFO<<"dayEntry path"<<dayEntry.path();
+        if (!boost::filesystem::is_directory(dayEntry)) continue;
+        if (oldestDay.empty() || dayEntry.path().filename() < oldestDay.filename())
+            oldestDay = dayEntry.path();
+    }
+
+     boost::filesystem::path oldestHour;
+    for (const auto& hourEntry : boost::filesystem::directory_iterator(oldestDay))
+    {
+        if (!boost::filesystem::is_directory(hourEntry)) continue;
+        if (oldestHour.empty() || hourEntry.path().filename() < oldestHour.filename())
+            LOG_INFO<<"hourEntry path"<<hourEntry.path();
+            oldestHour = hourEntry.path();
+    }
+    return oldestHour;
+}
+
+
+ 
+
+   void manageDirectory()
   {
     auto comparator = [](const std::pair<boost::filesystem::path, uint64_t> &a,
-                         const std::pair<boost::filesystem::path, uint64_t> &b)
+                        const std::pair<boost::filesystem::path, uint64_t> &b)
     {
       return a.second < b.second;
     };
     while (archiveSize > mProps.lowerWaterMark)
     {
-      foldVector.clear();
-      for (const auto &entry : boost::filesystem::directory_iterator(mProps.pathToWatch))
+      for (const auto &camFolder :
+           boost::filesystem::directory_iterator(mProps.pathToWatch))
       {
-        if (boost::filesystem::is_directory(entry))
-        {
-          foldVector.push_back({entry.path(), boost::filesystem::last_write_time(entry)});
-        }
-      }
-      if (foldVector.empty())
-        break;
-      std::sort(foldVector.begin(), foldVector.end(), comparator);
+        
+        boost::filesystem::path oldHrDir = getOldestHourDirByName(camFolder);
 
+         if (!boost::filesystem::exists(oldHrDir) || !boost::filesystem::is_directory(oldHrDir))
+        {
+            LOG_ERROR << "Directory does not exist or is not a directory: " << oldHrDir.string();
+            continue;
+        }
+
+        uint64_t lastWrite = boost::filesystem::last_write_time(oldHrDir);
+
+            // Print oldest hour dir and its last write time for each camera
+            std::time_t t = static_cast<std::time_t>(lastWrite);
+            BOOST_LOG_TRIVIAL(info) << "Camera: " << camFolder.path().string()
+                                    << " | Oldest Hour Dir: " << oldHrDir.string()
+                                    << " | Last Write: " << std::asctime(std::localtime(&t));
+
+        foldVector.push_back(
+            {oldHrDir, boost::filesystem::last_write_time(oldHrDir)});
+      }
+
+        
+      sort(foldVector.begin(), foldVector.end(),
+           comparator); // Sorting the vector
+
+      BOOST_LOG_TRIVIAL(info) << "Contents of foldVector:";
+        for (const auto &item : foldVector)
+        {
+            std::time_t t = static_cast<std::time_t>(item.second);
+            BOOST_LOG_TRIVIAL(info) << "Dir: " << item.first.string()
+                                    << " | Last Write: " << std::asctime(std::localtime(&t));
+        }
+
+         if (foldVector.empty())
+       {
+          LOG_ERROR << "No valid directories to delete.";
+          break;
+       }
+
+      uint64_t tempSize = 0;
       boost::filesystem::path delDir = foldVector[0].first;
-      LOG_INFO << "Deleting directory : " << delDir.string();
-      uint64_t tempSize = estimateDirectorySize(delDir);
-      archiveSize -= tempSize;
+
+        if (!boost::filesystem::exists(delDir) || !boost::filesystem::is_directory(delDir))
+       {
+          LOG_ERROR << "Directory to delete does not exist or is not a directory: " << delDir.string();
+          foldVector.clear();
+          continue;
+       }
+       BOOST_LOG_TRIVIAL(info) << "Deleting folder : " << delDir.string();
+       tempSize = estimateDirectorySize(delDir);
+       archiveSize = archiveSize - tempSize;
+       LOG_INFO<<"archive size after deleting"<<archiveSize;
       try
       {
         boost::filesystem::remove_all(delDir);
         boost::filesystem::path parentDir = delDir.parent_path();
-        if (boost::filesystem::is_empty(parentDir))
+         if (boost::filesystem::exists(parentDir) && boost::filesystem::is_directory(parentDir) && boost::filesystem::is_empty(parentDir))
         {
-          LOG_INFO << "Deleting parent directory : " << parentDir.string();
-          boost::filesystem::remove_all(parentDir);
+            BOOST_LOG_TRIVIAL(info) << "Deleting parent directory : " << parentDir.string();
+            try {
+                boost::filesystem::remove_all(parentDir);
+            } catch (const std::exception& e) {
+                LOG_ERROR << "Could not delete parent directory: " << e.what();
+            }
         }
       }
       catch (...)
       {
         LOG_ERROR << "Could not delete directory!..";
       }
+      foldVector.clear();
+      LOG_INFO<<"clearing the folder vectors";
+   
     }
   }
-
   uint64_t diskOperation()
   {
     archiveSize = estimateDirectorySize(mProps.pathToWatch);
+    LOG_INFO<<"archive size:"<<archiveSize;
     if (archiveSize > mProps.upperWaterMark)
     {
+      LOG_INFO<<"upw hit manageDirectory:"<<mProps.upperWaterMark;
       manageDirectory();
     }
     else
@@ -196,9 +280,13 @@ bool ArchiveSpaceManager::produce()
   {
     finalArchiveSpace = mDetail->diskOperation();
   }
+   catch (const std::exception& e)
+  {
+    LOG_ERROR << "Archive Disk Manager encountered an error: " << e.what();
+  }
   catch (...)
   {
-    LOG_ERROR << "Archive Disk Manager encountered an error.";
+    LOG_ERROR << "Archive Disk Manager encountered an unknown error.";
   }
   return true;
 }

--- a/base/src/Mp4ReaderSource.cpp
+++ b/base/src/Mp4ReaderSource.cpp
@@ -289,13 +289,56 @@ public:
 		return mState.mSerFormatVersion;
 	}
 
-	void setPlayback(float _speed, bool _direction)
+		void setPlayback(float _speed, bool _direction)
 	{
-		if (_speed != mState.speed)
+		// Update both speed variables for consistency
+		bool speedChanged = (_speed != playbackSpeed);
+		if (speedChanged)
 		{
+			playbackSpeed = _speed;
 			mState.speed = _speed;
+
+			// Only update FPS if video is open and forceFPS is not enabled
+			if (mState.demux && !mProps.forceFPS)
+			{
+				// For speeds < 8x: Adjust FPS without frame dropping (slow-mo, 1x, 2x, 4x)
+				// All frames are read, but delivered at different rate
+				if (playbackSpeed < 4)
+				{
+					mProps.fps = mFPS * playbackSpeed;
+					LOG_INFO << "Playback speed changed to <" << playbackSpeed << "x>, FPS updated to <" << mProps.fps << ">";
+					// Update Module's FPS directly without triggering full setProps
+					// This only updates FPS in the Module, avoiding video reinitialization
+					setMp4ReaderProps(mProps);
+				}
+				// For 4x, 8x, 16x, 32x: Use I-frame skipping mode
+				// GOP-based FPS adjustment + randomSeek in produceFrames
+				else if (playbackSpeed == 4  || playbackSpeed == 8 || playbackSpeed == 16 || playbackSpeed == 32)
+				{
+					auto gop = getGop();
+					if (gop)
+					{
+						mProps.fps = (mFPS * playbackSpeed) / gop;
+						LOG_INFO << "Playback speed changed to <" << playbackSpeed << "x> with GOP <" << gop << ">, FPS updated to <" << mProps.fps << ">";
+					}
+					else
+					{
+						mProps.fps = mFPS * playbackSpeed;
+						LOG_WARNING << "GOP is 0, using fallback FPS calculation: <" << mProps.fps << ">";
+					}
+					setMp4ReaderProps(mProps);
+				}
+				else
+				{
+					// Unsupported speed
+					LOG_WARNING << "Playback speed <" << playbackSpeed << "x> not explicitly supported. Using direct FPS multiplication.";
+					mProps.fps = mFPS * playbackSpeed;
+					setMp4ReaderProps(mProps);
+				}
+			}
 		}
-		// only if direction changes
+
+		// Handle direction changes
 		if (mState.direction != _direction)
 		{
 			mState.direction = _direction;
@@ -347,7 +390,7 @@ public:
 			setMetadata();
 		}
 	}
-
+	
 	bool getVideoRangeFromCache(std::string& videoPath, uint64_t& start_ts, uint64_t& end_ts)
 	{
 		return cof->fetchFromCache(videoPath, start_ts, end_ts);
@@ -557,6 +600,7 @@ public:
 
 		LOG_INFO << "opening video <" << filePath << ">";
 		ret = mp4_demux_open(filePath.c_str(), &mState.demux);
+		LOG_INFO << "mp4_demux_open ret <" << ret << "> demux <" << mState.demux << ">";
 		if (ret < 0)
 		{
 			// TODO: Behaviour yet to be decided in case a file is deleted while it is cached, generating a hole in the cache.
@@ -622,14 +666,16 @@ public:
 				// todo: Implement a way for mp4reader to update FPS when opening a new video in parseFS enabled mode. Must not set parseFS disabled in a loop.
 				auto propsFPS = mProps.fps;
 				mProps.fps = mFPS;
+				LOG_INFO << "Calling getGop()";
 				auto gop = getGop();
+				LOG_INFO << "getGop() returned <" << gop << ">";
 				mProps.fps = mFPS * playbackSpeed;
 				if (mProps.forceFPS)
 				{
 					mProps.fps = propsFPS;
 					mFPS = propsFPS;
 				}
-				if (playbackSpeed == 8 || playbackSpeed == 16 || playbackSpeed == 32)
+				if (playbackSpeed ==  4 || playbackSpeed == 8 || playbackSpeed == 16 || playbackSpeed == 32)
 				{
 					if (gop)
 					{
@@ -1817,7 +1863,7 @@ bool Mp4ReaderDetailH264::produceFrames(frame_container& frames)
 		isMp4SeekFrame = false;
 		setMetadata();
 	}
-	if((playbackSpeed == 8 || playbackSpeed == 16 || playbackSpeed == 32))
+	if((playbackSpeed == 4 || playbackSpeed == 8 || playbackSpeed == 16 || playbackSpeed == 32))
 	{
 		if(mDirection)
 		{
@@ -1856,14 +1902,18 @@ Mp4ReaderSource::~Mp4ReaderSource() {}
 
 bool Mp4ReaderSource::init()
 {
+	LOG_INFO << "Mp4ReaderSource::init() started";
 	if (!Module::init())
 	{
 		APErrorObject error(0, "MP4Reader init error");
     	executeErrorCallback(error);
 		return false;
 	}
+	LOG_INFO << "Module::init() finished";
 	auto outMetadata = getFirstOutputMetadata();
+	LOG_INFO << "outMetadata <" << outMetadata.get() << ">";
 	auto  mFrameType = outMetadata->getFrameType();
+	LOG_INFO << "mFrameType <" << mFrameType << ">";
 	if (mFrameType == FrameMetadata::FrameType::ENCODED_IMAGE)
 	{
 		mDetail.reset(new Mp4ReaderDetailJpeg(
@@ -1912,7 +1962,15 @@ bool Mp4ReaderSource::init()
 	mDetail->h264ImagePinId = h264ImagePinId;
 	mDetail->metadataFramePinId = metadataFramePinId;
 	mDetail->controlModule = controlModule;
-	return mDetail->Init();
+
+	bool initResult = mDetail->Init();
+	if (initResult && props.playbackSpeed != 1.0f)
+	{
+		LOG_INFO << "Applying initial playback speed from props: " << props.playbackSpeed << "x";
+		mDetail->setPlayback(props.playbackSpeed, props.direction);
+	}
+
+	return initResult;
 }
 
 void Mp4ReaderSource::setImageMetadata(std::string& pinId, framemetadata_sp& metadata)
@@ -2061,6 +2119,12 @@ bool Mp4ReaderSource::changePlayback(float speed, bool direction)
 	return queuePlayPauseCommand(ppc);
 }
 
+bool Mp4ReaderSource::changePlaybackSpeed(float speed, bool direction)
+{
+	Mp4ReaderPlaybackSpeedCommand cmd(speed, direction);
+	return queueCommand(cmd, true);
+}
+
 bool Mp4ReaderSource::handleCommand(Command::CommandType type, frame_sp& frame)
 {
 	if (type == Command::CommandType::Seek)
@@ -2068,6 +2132,13 @@ bool Mp4ReaderSource::handleCommand(Command::CommandType type, frame_sp& frame)
 		Mp4SeekCommand seekCmd;
 		getCommand(seekCmd, frame);
 		return mDetail->randomSeek(seekCmd.seekStartTS, seekCmd.forceReopen);
+	}
+	else if (type == Command::CommandType::Mp4ReaderPlaybackSpeed)
+	{
+		Mp4ReaderPlaybackSpeedCommand speedCmd;
+		getCommand(speedCmd, frame);
+		mDetail->setPlayback(speedCmd.playbackSpeed, speedCmd.direction);
+		return true;
 	}
 	else
 	{

--- a/base/src/Mp4ReaderSource.cpp
+++ b/base/src/Mp4ReaderSource.cpp
@@ -174,6 +174,8 @@ public:
 			cof->clearCache();
 			if (tempVideoPath == mState.mVideoPath)
 			{
+				// When only props are being updated (same video path), preserve playbackSpeed and fps
+				// from the incoming props (which should already have the correct values from setPlayback)
 				updateMstate(props, tempVideoPath);
 				return;
 			}
@@ -297,6 +299,7 @@ public:
 		{
 			playbackSpeed = _speed;
 			mState.speed = _speed;
+			mProps.playbackSpeed = _speed;
 
 			// Only update FPS if video is open and forceFPS is not enabled
 			if (mState.demux && !mProps.forceFPS)
@@ -2096,15 +2099,28 @@ bool Mp4ReaderSource::validateOutputPins()
 
 Mp4ReaderSourceProps Mp4ReaderSource::getProps()
 {
+	// Expose the latest effective props from the detail object (includes playbackSpeed / fps updates).
 	return mDetail->mProps;
 }
 
 bool Mp4ReaderSource::handlePropsChange(frame_sp& frame)
 {
-	bool direction = getPlayDirection();
-	Mp4ReaderSourceProps props(mDetail->mProps.videoPath, mDetail->mProps.parseFS, mDetail->mProps.reInitInterval, direction, mDetail->mProps.readLoop, mDetail->mProps.giveLiveTS, mDetail->mProps.parseFSTimeoutDuration, mDetail->mProps.bFramesEnabled);
-	bool ret = Module::handlePropsChange(frame, props);
-	mDetail->setProps(props);
+	// Start from the latest internal props (which already include any playbackSpeed/FPS changes)
+	Mp4ReaderSourceProps newProps = mDetail->mProps;
+	// Only override direction from the current play state
+	newProps.direction = getPlayDirection();
+	
+	// Ensure playbackSpeed and fps are preserved from mDetail->mProps
+	// (they should already be there, but be explicit to avoid any issues)
+	newProps.playbackSpeed = mDetail->mProps.playbackSpeed;
+	newProps.fps = mDetail->mProps.fps;
+
+	// Let the base Module apply these props (timers, logging, etc.)
+	bool ret = Module::handlePropsChange(frame, newProps);
+
+	// Keep both the Module-level props and internal detail props in sync
+	props = newProps;
+	mDetail->setProps(newProps);
 	return ret;
 }
 

--- a/base/src/Mp4WriterSink.cpp
+++ b/base/src/Mp4WriterSink.cpp
@@ -23,57 +23,22 @@ public:
   DTSCalcStrategyType type;
 };
 
-class DTSPassThroughStrategy : public DTSCalcStrategy {
+ class DTSPassThroughStrategy : public DTSCalcStrategy {
 public:
   DTSPassThroughStrategy()
       : DTSCalcStrategy(DTSCalcStrategy::DTSCalcStrategyType::PASS_THROUGH) {}
 
-  int64_t getDTS(uint64_t &frameTS,
-                 uint64_t lastFrameTS,
+  int64_t getDTS(uint64_t &frameTS, uint64_t lastFrameTS,
                  uint16_t fps) override {
-
-    LOG_INFO << "[DTS][PassThrough] Input: frameTS=" << frameTS
-             << ", lastFrameTS=" << lastFrameTS
-             << ", fps=" << fps;
-
-    int64_t diffInMsecs =
-        static_cast<int64_t>(frameTS) - static_cast<int64_t>(lastFrameTS);
-
-    // Half frame duration in milliseconds (minimum 1 ms)
-    int64_t halfDurationInMsecs =
-        std::max<int64_t>(1, 1000 / (2 * fps));
-
-    LOG_INFO << "[DTS][PassThrough] Initial diff=" << diffInMsecs
-             << " ms, halfFrameDuration=" << halfDurationInMsecs << " ms";
-
-    if (diffInMsecs == 0) {
-      LOG_INFO << "[DTS][PassThrough] Duplicate timestamp detected. "
-               << "Adjusting frameTS forward by half frame duration";
-
-      uint64_t oldFrameTS = frameTS;
+    int64_t diffInMsecs = frameTS - lastFrameTS;
+    // half of the ideal duration of one frame i.e. (1/fps) secs
+    int64_t halfDurationInMsecs = static_cast<int64_t>(1000 / (2 * fps));
+    if (!diffInMsecs) {
       frameTS += halfDurationInMsecs;
-
-      LOG_INFO << "[DTS][PassThrough] frameTS adjusted: "
-               << oldFrameTS << " -> " << frameTS;
-
     } else if (diffInMsecs < 0) {
-      LOG_INFO << "[DTS][PassThrough] Backward timestamp detected. diff="
-               << diffInMsecs << " ms. "
-               << "Clamping frameTS to lastFrameTS + half frame duration";
-
-      uint64_t oldFrameTS = frameTS;
       frameTS = lastFrameTS + halfDurationInMsecs;
-
-      LOG_INFO << "[DTS][PassThrough] frameTS corrected: "
-               << oldFrameTS << " -> " << frameTS;
     }
-
-    diffInMsecs =
-        static_cast<int64_t>(frameTS) - static_cast<int64_t>(lastFrameTS);
-
-    LOG_INFO << "[DTS][PassThrough] Final DTS diff="
-             << diffInMsecs << " ms";
-
+    diffInMsecs = frameTS - lastFrameTS;
     return diffInMsecs;
   }
 };

--- a/base/src/OrderedCacheOfFiles.cpp
+++ b/base/src/OrderedCacheOfFiles.cpp
@@ -456,7 +456,19 @@ bool OrderedCacheOfFiles::getRandomSeekFile(uint64_t skipTS, bool direction, uin
 
 	if (!queryBeforeCacheStart)
 	{
-		bool isSkipFileInCache = getFileFromCache(skipTS, direction, skipVideoFile);
+		bool isSkipFileInCache=false;
+		try
+		{
+		 	isSkipFileInCache= getFileFromCache(skipTS, direction, skipVideoFile);
+		}
+		catch(Mp4_Exception& exception)
+		{
+			if (exception.getCode() == MP4_OCOF_END)
+			{
+				auto msg = "Reached End OF cache";
+				isSkipFileInCache=false;
+			}
+		}
 		if (isSkipFileInCache)
 		{
 			bool isTsInFile = isTimeStampInFile(skipVideoFile, skipTS);
@@ -502,7 +514,20 @@ bool OrderedCacheOfFiles::getRandomSeekFile(uint64_t skipTS, bool direction, uin
 	}
 
 	// check in updated cache data
-	bool isSkipFileInCache = getFileFromCache(skipTS, direction, skipVideoFile);
+	bool isSkipFileInCache=false;
+	try
+	{
+		isSkipFileInCache = getFileFromCache(skipTS, direction, skipVideoFile);
+	}
+	catch (Mp4_Exception& exception)
+	{
+		isSkipFileInCache=false;
+		if (exception.getCode() == MP4_OCOF_END)
+		{
+			auto msg = "Reached End OF cache";
+			throw Mp4Exception(MP4_OCOF_END, msg);
+		}
+	}
 	if (!isSkipFileInCache)
 	{
 		/*case: in case of fwd parse, cache might include last file on disk as relevant file,
@@ -564,6 +589,8 @@ bool OrderedCacheOfFiles::getFileFromCache(uint64_t timestamp, bool direction, s
 		if (exception.getCode() == MP4_OCOF_END)
 		{
 			fileName = "";
+			auto msg = "Reached End OF cache";
+			throw Mp4Exception(MP4_OCOF_END, msg);
 		}
 		return false;
 	}

--- a/base/test/mp4readersource_tests.cpp
+++ b/base/test/mp4readersource_tests.cpp
@@ -13,6 +13,8 @@
 #include "ExternalSinkModule.h"
 #include "test_utils.h"
 #include "Mp4ErrorFrame.h"
+#include "ImageDecoderCV.h"
+#include "ImageViewerModule.h"
 
 BOOST_AUTO_TEST_SUITE(mp4readersource_tests)
 
@@ -571,6 +573,41 @@ BOOST_AUTO_TEST_CASE(max_buffer_size_change_props)
 	mp4Reader->step();
 	frames = sink->pop();
 	BOOST_TEST((frames.find(pinId) != frames.end()));
+}
+
+
+BOOST_AUTO_TEST_CASE(mp4_4x_playback_display)
+{
+	std::string videoPath = "/home/developer/ApraPipes/data/Mp4_videos/h264_video/20221010/0012/1668064027062.mp4";
+	auto frameType = FrameMetadata::FrameType::ENCODED_IMAGE;
+	auto encodedImageMetadata = framemetadata_sp(new EncodedImageMetadata(0, 0));
+	bool parseFS = false;
+
+	auto mp4ReaderProps = Mp4ReaderSourceProps(videoPath, parseFS, 0, true, false, false);
+	mp4ReaderProps.playbackSpeed = 4.0f;
+	auto mp4Reader = boost::shared_ptr<Mp4ReaderSource>(new Mp4ReaderSource(mp4ReaderProps));
+	mp4Reader->addOutPutPin(encodedImageMetadata);
+
+	auto decoderProps = ImageDecoderCVProps();
+	auto decoder = boost::shared_ptr<ImageDecoderCV>(new ImageDecoderCV(decoderProps));
+	auto rawImageMetadata = framemetadata_sp(new RawImageMetadata());
+	decoder->addOutputPin(rawImageMetadata);
+	mp4Reader->setNext(decoder);
+
+	auto viewerProps = ImageViewerModuleProps("4x Playback Display");
+	auto viewer = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(viewerProps));
+	decoder->setNext(viewer);
+
+	PipeLine p("4x_playback");
+	p.appendModule(mp4Reader);
+	BOOST_TEST(p.init());
+
+	p.run_all_threaded();
+	boost::this_thread::sleep_for(boost::chrono::seconds(5));
+
+	p.stop();
+	p.term();
+	p.wait_for_all();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/base/test/mp4readersource_tests.cpp
+++ b/base/test/mp4readersource_tests.cpp
@@ -576,38 +576,241 @@ BOOST_AUTO_TEST_CASE(max_buffer_size_change_props)
 }
 
 
-BOOST_AUTO_TEST_CASE(mp4_4x_playback_display)
+BOOST_AUTO_TEST_CASE(playrate_1x_all_frames_delivered)
 {
-	std::string videoPath = "/home/developer/ApraPipes/data/Mp4_videos/h264_video/20221010/0012/1668064027062.mp4";
-	auto frameType = FrameMetadata::FrameType::ENCODED_IMAGE;
-	auto encodedImageMetadata = framemetadata_sp(new EncodedImageMetadata(0, 0));
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	double baseFPS = s.mp4Reader->getOpenVideoFPS();
+	int totalFrames = s.mp4Reader->getOpenVideoFrameCount();
+
+	// At 1x, all frames should be delivered, FPS = baseFPS
+	auto props = s.mp4Reader->getProps();
+	BOOST_TEST(props.fps == baseFPS, boost::test_tools::tolerance(0.01));
+
+	// Read 10 consecutive frames and verify timestamps are monotonically increasing
+	uint64_t prevTS = 0;
+	for (int i = 0; i < 10; i++)
+	{
+		s.mp4Reader->step();
+		auto frames = s.sink->pop();
+		if (frames.empty()) continue;
+		auto frame = frames.begin()->second;
+		BOOST_TEST(frame->timestamp > prevTS);
+		prevTS = frame->timestamp;
+	}
+}
+
+BOOST_AUTO_TEST_CASE(playrate_2x_fps_doubled)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	double baseFPS = s.mp4Reader->getOpenVideoFPS();
+
+	s.mp4Reader->changePlaybackSpeed(2.0f, true);
+	s.mp4Reader->step(); // process command
+	s.mp4Reader->step(); // process props change
+
+	auto props = s.mp4Reader->getProps();
+	BOOST_TEST(props.playbackSpeed == 2.0f);
+	// At 2x: FPS should be baseFPS * 2, all frames still delivered
+	BOOST_TEST(props.fps == baseFPS * 2.0f, boost::test_tools::tolerance(0.01));
+
+	// Frames should still be monotonically increasing (no frame skipping at 2x)
+	uint64_t prevTS = 0;
+	for (int i = 0; i < 10; i++)
+	{
+		s.mp4Reader->step();
+		auto frames = s.sink->pop();
+		if (frames.empty()) continue;
+		auto frame = frames.begin()->second;
+		BOOST_TEST(frame->timestamp > prevTS);
+		prevTS = frame->timestamp;
+	}
+}
+
+BOOST_AUTO_TEST_CASE(playrate_4x_iframe_skipping)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	double baseFPS = s.mp4Reader->getOpenVideoFPS();
+
+	s.mp4Reader->changePlaybackSpeed(4.0f, true);
+	s.mp4Reader->step(); // process command
+	s.mp4Reader->step(); // process props change
+
+	auto props = s.mp4Reader->getProps();
+	BOOST_TEST(props.playbackSpeed == 4.0f);
+
+	// At 4x: I-frame skipping mode, FPS = (baseFPS * 4) / GOP
+	// Should NOT equal baseFPS * 4 (GOP division applies)
+	BOOST_TEST(props.fps != baseFPS * 4.0f);
+	// FPS should be less than baseFPS * 4 (GOP > 1)
+	BOOST_TEST(props.fps < baseFPS * 4.0f);
+
+	// At 4x, only I-frames are delivered, so timestamp gaps should be > 1 frame interval
+	double frameIntervalMs = 1000.0 / baseFPS;
+	uint64_t prevTS = 0;
+	int frameCount = 0;
+	for (int i = 0; i < 5; i++)
+	{
+		s.mp4Reader->step();
+		auto frames = s.sink->pop();
+		if (frames.empty()) continue;
+		auto frame = frames.begin()->second;
+		if (prevTS > 0)
+		{
+			uint64_t gap = frame->timestamp - prevTS;
+			// Gap should be larger than a single frame interval (I-frame skipping)
+			BOOST_TEST(gap > static_cast<uint64_t>(frameIntervalMs));
+		}
+		prevTS = frame->timestamp;
+		frameCount++;
+	}
+	BOOST_TEST(frameCount > 0);
+}
+
+BOOST_AUTO_TEST_CASE(playrate_switch_1x_to_4x_and_back)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	double baseFPS = s.mp4Reader->getOpenVideoFPS();
+
+	// Read a few frames at 1x
+	for (int i = 0; i < 5; i++)
+	{
+		s.mp4Reader->step();
+		s.sink->pop();
+	}
+
+	// Switch to 4x
+	s.mp4Reader->changePlaybackSpeed(4.0f, true);
+	s.mp4Reader->step();
+	s.mp4Reader->step();
+	auto props = s.mp4Reader->getProps();
+	BOOST_TEST(props.playbackSpeed == 4.0f);
+	BOOST_TEST(props.fps < baseFPS * 4.0f); // GOP division applied
+
+	// Read a few frames at 4x
+	for (int i = 0; i < 3; i++)
+	{
+		s.mp4Reader->step();
+		s.sink->pop();
+	}
+
+	// Switch back to 1x
+	s.mp4Reader->changePlaybackSpeed(1.0f, true);
+	s.mp4Reader->step();
+	s.mp4Reader->step();
+	props = s.mp4Reader->getProps();
+	BOOST_TEST(props.playbackSpeed == 1.0f);
+	BOOST_TEST(props.fps == baseFPS, boost::test_tools::tolerance(0.01));
+}
+
+BOOST_AUTO_TEST_CASE(playrate_8x_fps_gop_adjusted)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	double baseFPS = s.mp4Reader->getOpenVideoFPS();
+
+	s.mp4Reader->changePlaybackSpeed(8.0f, true);
+	s.mp4Reader->step();
+	s.mp4Reader->step();
+
+	auto props = s.mp4Reader->getProps();
+	BOOST_TEST(props.playbackSpeed == 8.0f);
+	// At 8x: same I-frame skipping as 4x, GOP division applied
+	BOOST_TEST(props.fps < baseFPS * 8.0f);
+	BOOST_TEST(props.fps > 0.0f);
+}
+
+BOOST_AUTO_TEST_CASE(playrate_backward_1x)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
+	bool parseFS = false;
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	auto frameType = FrameMetadata::FrameType::H264_DATA;
+	SetupMp4ReaderTest s(videoPath, h264ImageMetadata, frameType, parseFS, false);
+
+	// Read a few frames forward first to get away from the start
+	for (int i = 0; i < 20; i++)
+	{
+		s.mp4Reader->step();
+		s.sink->pop();
+	}
+
+	// Switch to backward playback at 1x
+	s.mp4Reader->changePlayback(1.0f, false);
+	s.mp4Reader->step(); // process command
+
+	// Read frames and verify timestamps are monotonically decreasing
+	uint64_t prevTS = UINT64_MAX;
+	int validFrames = 0;
+	for (int i = 0; i < 5; i++)
+	{
+		s.mp4Reader->step();
+		auto frames = s.sink->pop();
+		if (frames.empty()) continue;
+		auto frame = frames.begin()->second;
+		if (prevTS != UINT64_MAX)
+		{
+			BOOST_TEST(frame->timestamp < prevTS);
+		}
+		prevTS = frame->timestamp;
+		validFrames++;
+	}
+	BOOST_TEST(validFrames > 0);
+}
+
+BOOST_AUTO_TEST_CASE(playrate_initial_speed_from_props)
+{
+	std::string videoPath = "./data/Mp4_videos/h264_video_metadata/20230514/0011/1686723796848.mp4";
 	bool parseFS = false;
 
+	// Initialize with 2x speed in props
 	auto mp4ReaderProps = Mp4ReaderSourceProps(videoPath, parseFS, 0, true, false, false);
-	mp4ReaderProps.playbackSpeed = 4.0f;
+	mp4ReaderProps.playbackSpeed = 2.0f;
 	auto mp4Reader = boost::shared_ptr<Mp4ReaderSource>(new Mp4ReaderSource(mp4ReaderProps));
-	mp4Reader->addOutPutPin(encodedImageMetadata);
 
-	auto decoderProps = ImageDecoderCVProps();
-	auto decoder = boost::shared_ptr<ImageDecoderCV>(new ImageDecoderCV(decoderProps));
-	auto rawImageMetadata = framemetadata_sp(new RawImageMetadata());
-	decoder->addOutputPin(rawImageMetadata);
-	mp4Reader->setNext(decoder);
+	auto h264ImageMetadata = framemetadata_sp(new H264Metadata(0, 0));
+	mp4Reader->addOutPutPin(h264ImageMetadata);
+	auto mp4Metadata = framemetadata_sp(new Mp4VideoMetadata("v_1"));
+	mp4Reader->addOutPutPin(mp4Metadata);
 
-	auto viewerProps = ImageViewerModuleProps("4x Playback Display");
-	auto viewer = boost::shared_ptr<ImageViewerModule>(new ImageViewerModule(viewerProps));
-	decoder->setNext(viewer);
+	auto sink = boost::shared_ptr<ExternalSinkModule>(new ExternalSinkModule());
+	mp4Reader->setNext(sink);
 
-	PipeLine p("4x_playback");
-	p.appendModule(mp4Reader);
-	BOOST_TEST(p.init());
+	BOOST_TEST(mp4Reader->init());
+	BOOST_TEST(sink->init());
 
-	p.run_all_threaded();
-	boost::this_thread::sleep_for(boost::chrono::seconds(5));
+	double baseFPS = mp4Reader->getOpenVideoFPS();
+	auto props = mp4Reader->getProps();
 
-	p.stop();
-	p.term();
-	p.wait_for_all();
+	// FPS should already reflect 2x speed from init
+	BOOST_TEST(props.playbackSpeed == 2.0f);
+	BOOST_TEST(props.fps == baseFPS * 2.0f, boost::test_tools::tolerance(0.01));
+
+	mp4Reader->term();
+	sink->term();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Propagates seek failures near the live edge to the control module so that retry logic can be triggered. If retries are exhausted, playback is switched to live to maintain stream continuity.