### PR TITLE
fix(cmake): remove hardcoded CUDA 11.4 paths, use enable_language(CUDA) for JP5/JP6 compatibility

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.29)
-if(POLICY CMP0146)
-  cmake_policy(SET CMP0146 OLD)
-endif()
-
 OPTION(ENABLE_LINUX "Use this switch to enable LINUX" ON)
 OPTION(ENABLE_CUDA "Use this switch to enable CUDA" ON)
 OPTION(ENABLE_ARM64 "Use this switch to enable ARM64" OFF)
@@ -50,19 +46,6 @@ message(STATUS $ENV{PKG_CONFIG_PATH}">>>>>> PKG_CONFIG_PATH")
 find_package(PkgConfig REQUIRED)
 find_package(Boost COMPONENTS system thread filesystem serialization log chrono unit_test_framework REQUIRED)
 find_package(JPEG REQUIRED)
-set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda-11.4 CACHE PATH "CUDA toolkit root")
-set(CUDA_VERSION "11.4" CACHE STRING "CUDA version")
-set(CUDA_VERSION_STRING "11.4" CACHE STRING "CUDA version string")
-set(CUDA_INCLUDE_DIRS /usr/local/cuda-11.4/include CACHE PATH "CUDA include dirs")
-set(CUDA_LIBRARIES /usr/local/cuda-11.4/lib64/libcudart.so CACHE FILEPATH "CUDA libraries")
-set(CUDA_FOUND TRUE CACHE BOOL "CUDA found")
-macro(find_cuda_helper_libs _name)
-  find_library(CUDA_${_name}_LIBRARY
-    NAMES ${_name}
-    PATHS /usr/local/cuda-11.4/lib64
-    NO_DEFAULT_PATH)
-  mark_as_advanced(CUDA_${_name}_LIBRARY)
-endmacro()
 find_package(OpenCV CONFIG REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
## Summary

- Removes the hardcoded `/usr/local/cuda-11.4` CUDA path block added in the snapshot-videodecoder-integration work
- Removes the `CMP0146 OLD` policy workaround that was paired with it
- `enable_language(CUDA)` (already present at line 106) auto-detects the installed CUDA toolkit via `/usr/local/cuda` symlink — works on JP5 (CUDA 11.4), JP6 (CUDA 12.x), and x86

## Why the hardcoded paths broke JP6

JP6 ships with CUDA 12.x. The hardcoded variables pointed to `/usr/local/cuda-11.4/` which does not exist on JP6, causing CMake configure to fail.

## What was removed

```cmake
# Removed: CMP0146 policy block
if(POLICY CMP0146)
  cmake_policy(SET CMP0146 OLD)
endif()

# Removed: hardcoded CUDA 11.4 variable block
set(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda-11.4 ...)
set(CUDA_VERSION "11.4" ...)
set(CUDA_INCLUDE_DIRS /usr/local/cuda-11.4/include ...)
set(CUDA_LIBRARIES /usr/local/cuda-11.4/lib64/libcudart.so ...)
set(CUDA_FOUND TRUE ...)
macro(find_cuda_helper_libs _name) ... endmacro()
```

## Why no replacement needed

`CMP0146` is a `FindCUDA`-module policy. This project never calls `find_package(CUDA)` — it uses `enable_language(CUDA)` directly, which is the modern CMake approach. The policy and the hardcoded variables had no effect on the actual build; they were a red herring that happened to work on JP5 but broke on JP6.